### PR TITLE
LitghtTable link fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ layout: default
             <a href='http://www.strem.io' target='_blank' title='Stremio'>
               <img class='other-logo' src='../images/stremio.png' alt='Stremio'></a>
 
-            <a href='http://www.lighttable.com' target='_blank' title='Light Table'>
+            <a href='http://lighttable.com/' target='_blank' title='Light Table'>
               <img class='other-logo' src='../images/lighttable.png' alt='Light Table'></a>
 
             <a href='https://steelseries.com/engine' target='_blank' title='SteelSeries Engine 3'>

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ layout: default
             <a href='http://www.strem.io' target='_blank' title='Stremio'>
               <img class='other-logo' src='../images/stremio.png' alt='Stremio'></a>
 
-            <a href='http://lighttable.com/' target='_blank' title='Light Table'>
+            <a href='http://lighttable.com' target='_blank' title='Light Table'>
               <img class='other-logo' src='../images/lighttable.png' alt='Light Table'></a>
 
             <a href='https://steelseries.com/engine' target='_blank' title='SteelSeries Engine 3'>


### PR DESCRIPTION
There is no hostname `www.lighttable.com`, but `lighttable.com` works:
```
Z:\>ping www.lighttable.com
Ping request could not find host www.lighttable.com. Please check the name and try again.

Z:\>ping lighttable.com

Pinging lighttable.com [192.30.252.153] with 32 bytes of data:
Reply from 192.30.252.153: bytes=32 time=81ms TTL=52
Reply from 192.30.252.153: bytes=32 time=80ms TTL=52
Reply from 192.30.252.153: bytes=32 time=80ms TTL=52
Reply from 192.30.252.153: bytes=32 time=80ms TTL=52

Ping statistics for 192.30.252.153:
    Packets: Sent = 4, Received = 4, Lost = 0 (0% loss),
Approximate round trip times in milli-seconds:
    Minimum = 80ms, Maximum = 81ms, Average = 80ms
```