### PR TITLE
Sort docs by title

### DIFF
--- a/_docs/api/accelerator.md
+++ b/_docs/api/accelerator.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/accelerator.md'
 excerpt: "Define keyboard shortcuts."
 title: "Accelerator"
+sort_title: "accelerator"
 ---
 
 # Accelerator

--- a/_docs/api/app.md
+++ b/_docs/api/app.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/app.md'
 excerpt: "Control your application&apos;s event lifecycle."
 title: "app"
+sort_title: "app"
 ---
 
 # app

--- a/_docs/api/auto-updater.md
+++ b/_docs/api/auto-updater.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/auto-updater.md'
 excerpt: "Enable apps to automatically update themselves."
 title: "autoUpdater"
+sort_title: "autoupdater"
 ---
 
 # autoUpdater

--- a/_docs/api/browser-window.md
+++ b/_docs/api/browser-window.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/browser-window.md'
 excerpt: "Create and control browser windows."
 title: "BrowserWindow"
+sort_title: "browserwindow"
 ---
 
 # BrowserWindow

--- a/_docs/api/chrome-command-line-switches.md
+++ b/_docs/api/chrome-command-line-switches.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/chrome-command-line-switches.md'
 excerpt: "Command line switches supported by Electron."
 title: "Supported Chrome Command Line Switches"
+sort_title: "supported chrome command line switches"
 ---
 
 # Supported Chrome Command Line Switches

--- a/_docs/api/clipboard.md
+++ b/_docs/api/clipboard.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/clipboard.md'
 excerpt: "Perform copy and paste operations on the system clipboard."
 title: "clipboard"
+sort_title: "clipboard"
 ---
 
 # clipboard

--- a/_docs/api/content-tracing.md
+++ b/_docs/api/content-tracing.md
@@ -42,6 +42,7 @@ source_url: 'https://github.com/electron/electron/blob/master/docs/api/content-t
 excerpt: "Collect tracing data from Chromium&apos;s content module for finding performance
 bottlenecks and slow operations."
 title: "contentTracing"
+sort_title: "contenttracing"
 ---
 
 # contentTracing

--- a/_docs/api/crash-reporter.md
+++ b/_docs/api/crash-reporter.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/crash-reporter.md'
 excerpt: "Submit crash reports to a remote server."
 title: "crashReporter"
+sort_title: "crashreporter"
 ---
 
 # crashReporter

--- a/_docs/api/desktop-capturer.md
+++ b/_docs/api/desktop-capturer.md
@@ -42,6 +42,7 @@ source_url: 'https://github.com/electron/electron/blob/master/docs/api/desktop-c
 excerpt: "List <code>getUserMedia</code> sources for capturing audio, video, and images from a
 microphone, camera, or screen."
 title: "desktopCapturer"
+sort_title: "desktopcapturer"
 ---
 
 # desktopCapturer

--- a/_docs/api/dialog.md
+++ b/_docs/api/dialog.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/dialog.md'
 excerpt: "Display native system dialogs for opening and saving files, alerting, etc."
 title: "dialog"
+sort_title: "dialog"
 ---
 
 # dialog

--- a/_docs/api/download-item.md
+++ b/_docs/api/download-item.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/download-item.md'
 excerpt: "Control file downloads from remote sources."
 title: "DownloadItem"
+sort_title: "downloaditem"
 ---
 
 # DownloadItem

--- a/_docs/api/environment-variables.md
+++ b/_docs/api/environment-variables.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/environment-variables.md'
 excerpt: "Control application configuration and behavior without changing code."
 title: "Environment Variables"
+sort_title: "environment variables"
 ---
 
 # Environment Variables

--- a/_docs/api/file-object.md
+++ b/_docs/api/file-object.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/file-object.md'
 excerpt: "Use the HTML5 <code>File</code> API to work natively with files on the filesystem."
 title: "File object"
+sort_title: "file object"
 ---
 
 # `File` object

--- a/_docs/api/frameless-window.md
+++ b/_docs/api/frameless-window.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/frameless-window.md'
 excerpt: "Open a window without toolbars, borders, or other graphical &quot;chrome&quot;."
 title: "Frameless Window"
+sort_title: "frameless window"
 ---
 
 # Frameless Window

--- a/_docs/api/global-shortcut.md
+++ b/_docs/api/global-shortcut.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/global-shortcut.md'
 excerpt: "Detect keyboard events when the application does not have keyboard focus."
 title: "globalShortcut"
+sort_title: "globalshortcut"
 ---
 
 # globalShortcut

--- a/_docs/api/ipc-main.md
+++ b/_docs/api/ipc-main.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/ipc-main.md'
 excerpt: "Communicate asynchronously from the main process to renderer processes."
 title: "ipcMain"
+sort_title: "ipcmain"
 ---
 
 # ipcMain

--- a/_docs/api/ipc-renderer.md
+++ b/_docs/api/ipc-renderer.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/ipc-renderer.md'
 excerpt: "Communicate asynchronously from a renderer process to the main process."
 title: "ipcRenderer"
+sort_title: "ipcrenderer"
 ---
 
 # ipcRenderer

--- a/_docs/api/menu-item.md
+++ b/_docs/api/menu-item.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/menu-item.md'
 excerpt: "Add items to native application menus and context menus."
 title: "MenuItem"
+sort_title: "menuitem"
 ---
 
 # MenuItem

--- a/_docs/api/menu.md
+++ b/_docs/api/menu.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/menu.md'
 excerpt: "Create native application menus and context menus."
 title: "Menu"
+sort_title: "menu"
 ---
 
 # Menu

--- a/_docs/api/native-image.md
+++ b/_docs/api/native-image.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/native-image.md'
 excerpt: "Create tray, dock, and application icons using PNG or JPG files."
 title: "nativeImage"
+sort_title: "nativeimage"
 ---
 
 # nativeImage

--- a/_docs/api/power-monitor.md
+++ b/_docs/api/power-monitor.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/power-monitor.md'
 excerpt: "Monitor power state changes."
 title: "powerMonitor"
+sort_title: "powermonitor"
 ---
 
 # powerMonitor

--- a/_docs/api/power-save-blocker.md
+++ b/_docs/api/power-save-blocker.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/power-save-blocker.md'
 excerpt: "Block the system from entering low-power (sleep) mode."
 title: "powerSaveBlocker"
+sort_title: "powersaveblocker"
 ---
 
 # powerSaveBlocker

--- a/_docs/api/process.md
+++ b/_docs/api/process.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/process.md'
 excerpt: "Extensions to process object."
 title: "process"
+sort_title: "process"
 ---
 
 # process

--- a/_docs/api/protocol.md
+++ b/_docs/api/protocol.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/protocol.md'
 excerpt: "Register a custom protocol and intercept existing protocol requests."
 title: "protocol"
+sort_title: "protocol"
 ---
 
 # protocol

--- a/_docs/api/remote.md
+++ b/_docs/api/remote.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/remote.md'
 excerpt: "Use main process modules from the renderer process."
 title: "remote"
+sort_title: "remote"
 ---
 
 # remote

--- a/_docs/api/screen.md
+++ b/_docs/api/screen.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/screen.md'
 excerpt: "Retrieve information about screen size, displays, cursor position, etc."
 title: "screen"
+sort_title: "screen"
 ---
 
 # screen

--- a/_docs/api/session.md
+++ b/_docs/api/session.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/session.md'
 excerpt: "Manage browser sessions, cookies, cache, proxy settings, etc."
 title: "session"
+sort_title: "session"
 ---
 
 # session

--- a/_docs/api/shell.md
+++ b/_docs/api/shell.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/shell.md'
 excerpt: "Manage files and URLs using their default applications."
 title: "shell"
+sort_title: "shell"
 ---
 
 # shell

--- a/_docs/api/synopsis.md
+++ b/_docs/api/synopsis.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/synopsis.md'
 excerpt: "How to use Node.js and Electron APIs."
 title: "Synopsis"
+sort_title: "synopsis"
 ---
 
 # Synopsis

--- a/_docs/api/system-preferences.md
+++ b/_docs/api/system-preferences.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/system-preferences.md'
 excerpt: "Get system preferences."
 title: "systemPreferences"
+sort_title: "systempreferences"
 ---
 
 # systemPreferences

--- a/_docs/api/tray.md
+++ b/_docs/api/tray.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/tray.md'
 excerpt: "Add icons and context menus to the system&apos;s notification area."
 title: "Tray"
+sort_title: "tray"
 ---
 
 # Tray

--- a/_docs/api/web-contents.md
+++ b/_docs/api/web-contents.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/web-contents.md'
 excerpt: "Render and control web pages."
 title: "webContents"
+sort_title: "webcontents"
 ---
 
 # webContents

--- a/_docs/api/web-frame.md
+++ b/_docs/api/web-frame.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/web-frame.md'
 excerpt: "Customize the rendering of the current web page."
 title: "webFrame"
+sort_title: "webframe"
 ---
 
 # webFrame

--- a/_docs/api/web-view-tag.md
+++ b/_docs/api/web-view-tag.md
@@ -41,7 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/web-view-tag.md'
 excerpt: "Display external web content in an isolated frame and process."
 title: "&lt;webview&gt; Tag"
-sort_title: "&lt;webview&gt; tag"
+sort_title: "webview> tag"
 ---
 
 # `<webview>` Tag

--- a/_docs/api/web-view-tag.md
+++ b/_docs/api/web-view-tag.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/web-view-tag.md'
 excerpt: "Display external web content in an isolated frame and process."
 title: "&lt;webview&gt; Tag"
+sort_title: "&lt;webview&gt; tag"
 ---
 
 # `<webview>` Tag

--- a/_docs/api/window-open.md
+++ b/_docs/api/window-open.md
@@ -41,6 +41,7 @@ redirect_from:
 source_url: 'https://github.com/electron/electron/blob/master/docs/api/window-open.md'
 excerpt: "Open a new window and load a URL."
 title: "window.open Function"
+sort_title: "window.open function"
 ---
 
 # `window.open` Function

--- a/_docs/development/atom-shell-vs-node-webkit.md
+++ b/_docs/development/atom-shell-vs-node-webkit.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/atom-shell-vs-node-webkit/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/atom-shell-vs-node-webkit.md'
 title: "Technical Differences Between Electron and NW.js (formerly node-webkit)"
+sort_title: "technical differences between electron and nw.js (formerly node-webkit)"
 ---
 
 # Technical Differences Between Electron and NW.js (formerly node-webkit)

--- a/_docs/development/build-instructions-linux.md
+++ b/_docs/development/build-instructions-linux.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/build-instructions-linux/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/build-instructions-linux.md'
 title: "Build Instructions (Linux)"
+sort_title: "build instructions (linux)"
 ---
 
 # Build Instructions (Linux)

--- a/_docs/development/build-instructions-osx.md
+++ b/_docs/development/build-instructions-osx.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/build-instructions-osx/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/build-instructions-osx.md'
 title: "Build Instructions (OS X)"
+sort_title: "build instructions (os x)"
 ---
 
 # Build Instructions (OS X)

--- a/_docs/development/build-instructions-windows.md
+++ b/_docs/development/build-instructions-windows.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/build-instructions-windows/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/build-instructions-windows.md'
 title: "Build Instructions (Windows)"
+sort_title: "build instructions (windows)"
 ---
 
 # Build Instructions (Windows)

--- a/_docs/development/build-system-overview.md
+++ b/_docs/development/build-system-overview.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/build-system-overview/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/build-system-overview.md'
 title: "Build System Overview"
+sort_title: "build system overview"
 ---
 
 # Build System Overview

--- a/_docs/development/coding-style.md
+++ b/_docs/development/coding-style.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/coding-style/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/coding-style.md'
 title: "Coding Style"
+sort_title: "coding style"
 ---
 
 # Coding Style

--- a/_docs/development/debug-instructions-windows.md
+++ b/_docs/development/debug-instructions-windows.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/debug-instructions-windows/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/debug-instructions-windows.md'
 title: "Debugging on Windows"
+sort_title: "debugging on windows"
 ---
 
 # Debugging on Windows

--- a/_docs/development/setting-up-symbol-server.md
+++ b/_docs/development/setting-up-symbol-server.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/setting-up-symbol-server/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/setting-up-symbol-server.md'
 title: "Setting Up Symbol Server in Debugger"
+sort_title: "setting up symbol server in debugger"
 ---
 
 # Setting Up Symbol Server in Debugger

--- a/_docs/development/source-code-directory-structure.md
+++ b/_docs/development/source-code-directory-structure.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/development/source-code-directory-structure/
 source_url: 'https://github.com/electron/electron/blob/master/docs/development/source-code-directory-structure.md'
 title: "Source Code Directory Structure"
+sort_title: "source code directory structure"
 ---
 
 # Source Code Directory Structure

--- a/_docs/faq/electron-faq.md
+++ b/_docs/faq/electron-faq.md
@@ -42,6 +42,7 @@ redirect_from:
     - /docs/latest/faq/electron-faq/
 source_url: 'https://github.com/electron/electron/blob/master/docs/faq/electron-faq.md'
 title: "Electron FAQ"
+sort_title: "electron faq"
 ---
 
 # Electron FAQ

--- a/_docs/tutorial/application-distribution.md
+++ b/_docs/tutorial/application-distribution.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/application-distribution/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/application-distribution.md'
 title: "Application Distribution"
+sort_title: "application distribution"
 ---
 
 # Application Distribution

--- a/_docs/tutorial/application-packaging.md
+++ b/_docs/tutorial/application-packaging.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/application-packaging/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/application-packaging.md'
 title: "Application Packaging"
+sort_title: "application packaging"
 ---
 
 # Application Packaging

--- a/_docs/tutorial/debugging-main-process.md
+++ b/_docs/tutorial/debugging-main-process.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/debugging-main-process/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/debugging-main-process.md'
 title: "Debugging the Main Process"
+sort_title: "debugging the main process"
 ---
 
 # Debugging the Main Process

--- a/_docs/tutorial/desktop-environment-integration.md
+++ b/_docs/tutorial/desktop-environment-integration.md
@@ -50,6 +50,7 @@ application should not clutter the menu with advanced features that standard
 users won&apos;t need or one-time actions such as registration. Do not use tasks
 for promotional items such as upgrades or special offers."
 title: "Desktop Environment Integration"
+sort_title: "desktop environment integration"
 ---
 
 # Desktop Environment Integration

--- a/_docs/tutorial/devtools-extension.md
+++ b/_docs/tutorial/devtools-extension.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/devtools-extension/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/devtools-extension.md'
 title: "DevTools Extension"
+sort_title: "devtools extension"
 ---
 
 # DevTools Extension

--- a/_docs/tutorial/electron-versioning.md
+++ b/_docs/tutorial/electron-versioning.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/electron-versioning/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/electron-versioning.md'
 title: "Electron Versioning"
+sort_title: "electron versioning"
 ---
 
 # Electron Versioning

--- a/_docs/tutorial/mac-app-store-submission-guide.md
+++ b/_docs/tutorial/mac-app-store-submission-guide.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/mac-app-store-submission-guide/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/mac-app-store-submission-guide.md'
 title: "Mac App Store Submission Guide"
+sort_title: "mac app store submission guide"
 ---
 
 # Mac App Store Submission Guide

--- a/_docs/tutorial/online-offline-events.md
+++ b/_docs/tutorial/online-offline-events.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/online-offline-events/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/online-offline-events.md'
 title: "Online/Offline Event Detection"
+sort_title: "online/offline event detection"
 ---
 
 # Online/Offline Event Detection

--- a/_docs/tutorial/quick-start.md
+++ b/_docs/tutorial/quick-start.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/quick-start/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/quick-start.md'
 title: "Quick Start"
+sort_title: "quick start"
 ---
 
 # Quick Start

--- a/_docs/tutorial/security.md
+++ b/_docs/tutorial/security.md
@@ -44,6 +44,7 @@ Node integration enabled. Instead, use only local files (packaged together with
 your application) to execute Node code. To display remote content, use the
 <code>webview</code> tag and make sure to disable the <code>nodeIntegration</code>."
 title: "Security, Native Capabilities, and Your Responsibility"
+sort_title: "security, native capabilities, and your responsibility"
 ---
 
 # Security, Native Capabilities, and Your Responsibility

--- a/_docs/tutorial/supported-platforms.md
+++ b/_docs/tutorial/supported-platforms.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/supported-platforms/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/supported-platforms.md'
 title: "Supported Platforms"
+sort_title: "supported platforms"
 ---
 
 # Supported Platforms

--- a/_docs/tutorial/testing-on-headless-ci.md
+++ b/_docs/tutorial/testing-on-headless-ci.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/testing-on-headless-ci/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md'
 title: "Testing on Headless CI Systems (Travis CI, Jenkins)"
+sort_title: "testing on headless ci systems (travis ci, jenkins)"
 ---
 
 # Testing on Headless CI Systems (Travis CI, Jenkins)

--- a/_docs/tutorial/using-native-node-modules.md
+++ b/_docs/tutorial/using-native-node-modules.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/using-native-node-modules/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md'
 title: "Using Native Node Modules"
+sort_title: "using native node modules"
 ---
 
 # Using Native Node Modules

--- a/_docs/tutorial/using-pepper-flash-plugin.md
+++ b/_docs/tutorial/using-pepper-flash-plugin.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/using-pepper-flash-plugin/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/using-pepper-flash-plugin.md'
 title: "Using Pepper Flash Plugin"
+sort_title: "using pepper flash plugin"
 ---
 
 # Using Pepper Flash Plugin

--- a/_docs/tutorial/using-selenium-and-webdriver.md
+++ b/_docs/tutorial/using-selenium-and-webdriver.md
@@ -45,6 +45,7 @@ JavaScript execution, and more. ChromeDriver is a standalone server which
 implements WebDriver&apos;s wire protocol for Chromium. It is being developed by
 members of the Chromium and WebDriver teams."
 title: "Using Selenium and WebDriver"
+sort_title: "using selenium and webdriver"
 ---
 
 # Using Selenium and WebDriver

--- a/_docs/tutorial/using-widevine-cdm-plugin.md
+++ b/_docs/tutorial/using-widevine-cdm-plugin.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/using-widevine-cdm-plugin/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/using-widevine-cdm-plugin.md'
 title: "Using Widevine CDM Plugin"
+sort_title: "using widevine cdm plugin"
 ---
 
 # Using Widevine CDM Plugin

--- a/_docs/tutorial/windows-store-guide.md
+++ b/_docs/tutorial/windows-store-guide.md
@@ -40,6 +40,7 @@ redirect_from:
     - /docs/latest/tutorial/windows-store-guide/
 source_url: 'https://github.com/electron/electron/blob/master/docs/tutorial/windows-store-guide.md'
 title: "Windows Store Guide"
+sort_title: "windows store guide"
 ---
 
 # Windows Store Guide

--- a/_pages/api.md
+++ b/_pages/api.md
@@ -10,7 +10,8 @@ breadcrumb: API
 
 <table class="table table-ruled table-full-width table-with-spacious-first-column">
 
-{% for doc in site.docs %}
+{% assign docs = site.docs | sort: 'sort_title' %}
+{% for doc in docs %}
   {% if doc.category == 'API' %}
     <tr>
       <td><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></td>

--- a/_pages/development.md
+++ b/_pages/development.md
@@ -9,7 +9,8 @@ breadcrumb: Development
 <h2 class="docs-heading pb-3 mb-3"><span class="mega-octicon octicon-tools pr-3"></span>Developing Electron</h2>
 
 <ul class="docs-list">
-{% for doc in site.docs %}
+{% assign docs = site.docs | sort: 'sort_title' %}
+{% for doc in docs %}
   {% if doc.category == 'Development' %}
     <li>
       <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a>

--- a/_pages/docs.html
+++ b/_pages/docs.html
@@ -36,6 +36,8 @@ redirect_from:
 layout: default
 ---
 
+{% assign docs = site.docs | sort: 'sort_title' %}
+
 <div class='subtron'>
   <div class='container-narrow'>
     <h1><span class="mr-3 mr-lg-4">Electron Documentation</span><span class="docs-version">{{ site.latest_version }}</span></h1>
@@ -53,7 +55,7 @@ layout: default
         <div class="col-ms-12 col-lg-4">
           <h2 class="docs-heading pb-3 mb-3"><a class="docs-title" href="{{ site.baseurl }}/docs/guides/"><span class="mega-octicon octicon-book pr-3"></span>Guides</a></h2>
           <ul class="docs-list">
-          {% for doc in site.docs %}
+          {% for doc in docs %}
             {% if doc.category == 'Tutorial' %}
               <li>
                 <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a>
@@ -68,7 +70,7 @@ layout: default
           <h2 class="docs-heading pb-3 mb-3"><a class="docs-title" href="{{ site.baseurl }}/docs/api/"><span class="mega-octicon octicon-gear pr-3"></span>API Reference</a></h2>
             <h3>Main Process</h3>
             <ul class="docs-list">
-            {% for doc in site.docs %}
+            {% for doc in docs %}
               {% if doc.category == 'API' and site.data.processes[doc.title] == 'Main Process' %}
               <li>
                 <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a>
@@ -78,7 +80,7 @@ layout: default
             </ul>
             <h3>Renderer Process</h3>
             <ul class="docs-list">
-            {% for doc in site.docs %}
+            {% for doc in docs %}
               {% if doc.category == 'API' and site.data.processes[doc.title] == 'Renderer Process' %}
               <li>
                 <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a>
@@ -87,7 +89,7 @@ layout: default
             {% endfor %}
             </ul>
             <h3>Both Processes</h3>
-            {% for doc in site.docs %}
+            {% for doc in docs %}
             <ul class="docs-list">
               {% if doc.category == 'API' and site.data.processes[doc.title] == 'Main and Renderer Process' %}
               <li>
@@ -102,7 +104,7 @@ layout: default
         <div class="col-ms-12 col-lg-4">
           <h2 class="docs-heading pb-3 mb-3"><a class="docs-title" href="{{ site.baseurl }}/docs/development/"><span class="mega-octicon octicon-tools pr-3"></span>Advanced</a></h2>
           <ul class="docs-list">
-          {% for doc in site.docs %}
+          {% for doc in docs %}
             {% if doc.category == 'Development' %}
               <li>
                 <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a>

--- a/_pages/guides.md
+++ b/_pages/guides.md
@@ -12,7 +12,8 @@ breadcrumb: Guides
 <h2 class="docs-heading pb-3 mb-3"><span class="mega-octicon octicon-book pr-3"></span>Guides</h2>
 
 <ul class="docs-list">
-{% for doc in site.docs %}
+{% assign docs = site.docs | sort: 'sort_title' %}
+{% for doc in docs %}
   {% if doc.category == 'Tutorial' %}
     <li>
       <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a>

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -136,7 +136,7 @@ function frontMatterify (frontmatter) {
       var title = content('h1').first().text()
       if (title && title.length) {
         title = title.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\"/g, '\\\"')
-        frontmatter = frontmatter.toString().replace(frontmatterTail, `title: "${title}"\n${frontmatterTail}`)
+        frontmatter = frontmatter.toString().replace(frontmatterTail, `title: "${title}"\nsort_title: "${title.toLowerCase()}"\n${frontmatterTail}`)
       }
 
       this.push(frontmatter)

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -135,8 +135,10 @@ function frontMatterify (frontmatter) {
 
       var title = content('h1').first().text()
       if (title && title.length) {
-        title = title.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\"/g, '\\\"')
-        frontmatter = frontmatter.toString().replace(frontmatterTail, `title: "${title}"\nsort_title: "${title.toLowerCase()}"\n${frontmatterTail}`)
+        title = title.trim().replace(/\"/g, '\\\"')
+        var sortTitle = title.toLowerCase().replace(/^[^A-Za-z0-9]+/, '')
+        title = title.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        frontmatter = frontmatter.toString().replace(frontmatterTail, `title: "${title}"\nsort_title: "${sortTitle}"\n${frontmatterTail}`)
       }
 
       this.push(frontmatter)


### PR DESCRIPTION
Previously docs were sorted by their filename instead of their title.

This pull request switches it to generate a new `sort_title` config value when building the docs that will be used as the sorting key when iterating over them.

This should lead to consistent case-insensitive sorting on pages like http://electron.atom.io/docs/ and http://electron.atom.io/docs/api/

/cc @jlord 