### PR TITLE
Fix typo in _data/processes.yml

### DIFF
--- a/_data/processes.yml
+++ b/_data/processes.yml
@@ -1,7 +1,7 @@
 "Accelerator" : "Main Process"
 "app": "Main Process"
 "autoUpdater": "Main Process"
-"BrowserWWindow": "Main Process"
+"BrowserWindow": "Main Process"
 "clipboard": "Main and Renderer Process"
 "contentTracing": "Main Process"
 "crashReporter": "Main and Renderer Process"


### PR DESCRIPTION
- BrowserWindow is not listed on http://electron.atom.io/docs/ .
- http://electron.atom.io/docs/api/browser-window/ does not show its category.