### PR TITLE
Only create redirect URLs for older versions

### DIFF
--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -186,11 +186,14 @@ function constructDocMetadata (filepath) {
     metadata.breadcrumb = 'FAQ'
   }
 
-  metadata.redirect_from = config.available_versions.concat('latest')
-    .map(function (v) {
-      return `/` + filepath.split('/').splice(1).join('/')
-        .replace('docs/', `docs/${v}/`).replace('.md', '/')
-    })
+  // add redirect urls for all versions prior to 1.0
+  metadata.redirect_from = []
+  var allVers = config.available_versions.concat('latest')
+  allVers.forEach(function (ver) {
+    if (ver.match('v1.')) return
+    metadata.redirect_from.push(`/` + filepath.split('/').splice(1).join('/')
+      .replace('docs/', `docs/${ver}/`).replace('.md', '/'))
+  })
 
   return metadata
 }


### PR DESCRIPTION
We create redirect urls for each page in the docs because we've changed what docs are on the site and where they are. This way old URLs that persist in Google searches will still take the user to the correct spot.

We were generating this URL based on all versions of Electron listed in the `_config` but the old urls only exist for versions prior to `1.0`. 

This PR updates the script so that we're only creating redirect URLs for versions prior to `1.0`.

You can see the result of this change in the new docs PR #302.

/cc @kevinsawicki 