### PR TITLE
Add meetups section to community page

### DIFF
--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -3,3 +3,28 @@
   location: San Francisco, California
   country: USA
   href: http://www.meetup.com/Bay-Area-Electron-User-Group
+-
+  name: ElectronDC
+  location: Washington D.C.
+  country: USA
+  href: http://www.meetup.com/ELECTRONDC
+-
+  name: Electron Korea
+  location: Seoul
+  country: South Korea
+  href: http://www.meetup.com/electron-kr
+-
+  name: Austin ElectronJS Meetup
+  location: Austin, Texas
+  country: USA
+  href: http://www.meetup.com/Austin-ElectronJs-Meetup
+-
+  name: ElectronJS Paris
+  location: Paris
+  country: France
+  href: http://www.meetup.com/Meetup-Electron-JS-Paris
+-
+  name: Electron/Atom
+  location: Cambridge, Massachusetts
+  country: USA
+  href: http://www.meetup.com/Electron-Atom

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -1,0 +1,5 @@
+-
+  name: Bay Area Electron User Group
+  location: San Francisco, California
+  country: USA
+  href: http://www.meetup.com/Bay-Area-Electron-User-Group

--- a/_pages/community.html
+++ b/_pages/community.html
@@ -8,7 +8,7 @@ layout: default
   <div class='container-narrow'>
     <h1>Electron Community</h1>
     <p class="lead mb-3">
-      Tools, boilerplates, videos, and more from Electron's <a href="https://github.com/sindresorhus/awesome-electron">awesome</a> open-source contributors.
+      Tools, boilerplates, videos, and more from Electron's <a href="https://github.com/sindresorhus/awesome-electron">awesome</a> open-source contributors. Find or add <a href="#meetups">meetups</a> near you.
     </p>
   </div>
 </div>
@@ -87,6 +87,24 @@ layout: default
       repository.<br>
       Something missing?
       <a href="https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md">Make a pull request</a>.
+    </p>
+
+    <h2 id="meetups" class="mt-7">Meetups</h2>
+    <table class="table table-ruled table-full-width table-with-spacious-first-column mb-7">
+      {% for item in site.data.meetups %}
+          <tr>
+            <td>
+              <a href="{{ item.href }}">{{ item.name }}</a>
+            </td>
+            <td>
+              {{ item.location }}, {{ item.country }}
+            </td>
+          </tr>
+      {% endfor %}
+    </table>
+
+    <p class="mt-3 mt-md-6">
+      To add a meetup, edit <code>_data/meetups.yml</code> and <a href="https://github.com/electron/electron.atom.io/blob/gh-pages/_data/meetups.yml" target="_blank">make a pull request</a>.
     </p>
   </div>
 </section>


### PR DESCRIPTION
This adds a section at the bottom of the page to list Electron meetups.

The data comes from a new `_data/meetups.yml` file that people can henceforth add there meet up to! 

<img width="932" alt="screen shot 2016-05-27 at 2 35 21 pm" src="https://cloud.githubusercontent.com/assets/1305617/15621847/c1503314-2418-11e6-87b4-7edac272be22.png">

---
---

<img width="959" alt="screen shot 2016-05-27 at 2 35 14 pm" src="https://cloud.githubusercontent.com/assets/1305617/15621848/c472345c-2418-11e6-9e85-c29352c1c183.png">

/cc @kevinsawicki 

Closes #304 