### PR TITLE
Update readme and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,22 @@ Add your app to the list by editing [_data/apps.yml](/_data/apps.yml).
   icon: "lowercase-and-url-friendly.png"
 ```
 
+## Adding a meetup to the site
+
+If you want to add a meetup to the community site please open a pull request.
+
+Add the meetup to the list by editing [_data/meetups.yml](/_data/meetups.yml).
+
+```yml
+-
+  name: Name of Group
+  location: City, State (if applicable)
+  country: Country
+  href: Link to meetup's site
+```
+
+**Please add the meetup at the bottom of the list**.
+
 ## Documentation
 
 The documentation on this site is pulled directly from the `electron/electron` repository's `docs` directory. Contributions to the documentation should be made there: [electron/electron](https://github.com/electron/electron/tree/master/docs).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ npm install
 
 Versions of Electron documentation are fetched from the `electron/electron` repository's `docs` directory. The site contains the latest version of docs and links to older versions of the docs in the repository.
 
-To fetch documentation at a specific version:
+To fetch documentation for a specific version:
 
 ```bash
 $ script/docs <version> [options]
@@ -44,7 +44,7 @@ $ script/docs v0.26.0 --latest
 ```
 Options:
 
-`--latest` Set this version as the latest version of Electron in `_config.yml` and this documentation replaces the existing documentation.
+`--latest` Set this version as the latest version of Electron in `_config.yml` and replace the existing documentation.
 
 #### Release Notes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # electron.atom.io
 
-The [website](http://electron.atom.io) for [Electron](https://github.com/electron/electron) (formerly known as Atom-Shell).
+The [website](http://electron.atom.io) for [Electron](https://github.com/electron/electron): [electron.atom.io](http://electron.atom.io).
+
+**[Add a project to electron.atom.io/apps](CONTRIBUTING.md#adding-an-app-or-project-to-the-site)**
+**[Add a meetup to electron.atom.io/community](CONTRIBUTING.md#adding-a-meetup-to-the-site)**
 
 ### Build
 
@@ -17,9 +20,9 @@ npm start
 
 ### CLI for Docs, Releases & Version Information
 
-This site has versioned documentation, recent release change logs and the current versions of Node.js, Chromium and V8 that are used in Electron.
+This site contains the latest version of Electron docs, recent release change logs and the current versions of Node.js, Chromium and V8 that are used in Electron.
 
-Each of these are updated upon a **minor** release of Electron. They're done so with the command line interface detailed below.
+Each of these are updated here when a new Electron is released. They're done so with the command line interface detailed below.
 
  You'll need [Node.js](http://www.nodejs.org/download) installed on your system in order to use the CLI. Then you can install the dependencies:
 
@@ -28,9 +31,11 @@ $ cd electron.atom.io
 $ npm install
 ```
 
-#### Versioned Documentation
+#### Documentation
 
-Versions of Electron documentation are fetched from the `electron/electron` repository's `docs` directory. To fetch documentation at a specific version:
+Versions of Electron documentation are fetched from the `electron/electron` repository's `docs` directory. The site contains the latest version of docs and links to older versions of the docs in the repository.
+
+To fetch documentation at a specific version:
 
 ```bash
 $ script/docs <version> [options]
@@ -39,7 +44,7 @@ $ script/docs v0.26.0 --latest
 ```
 Options:
 
-`--latest` Set this version as the latest version of documentation
+`--latest` Set this version as the latest version of Electron in `_config.yml` and this documentation replaces the existing documentation.
 
 #### Release Notes
 
@@ -51,7 +56,7 @@ $ script/releases
 
 #### Updating Node.js, Chromium and V8 Versions in use in Electron
 
-To update the `_config.yml` in this site with the versions of Node.js, Chromium and V8 that the latest [minor release] of Electron is using run:
+To update the `_config.yml` in this site with the versions of Node.js, Chromium and V8 that the latest release of Electron is using run:
 
 ```bash
 $ script/versions

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 The [website](http://electron.atom.io) for [Electron](https://github.com/electron/electron): [electron.atom.io](http://electron.atom.io).
 
-**[Add a project to electron.atom.io/apps](CONTRIBUTING.md#adding-an-app-or-project-to-the-site)**
-**[Add a meetup to electron.atom.io/community](CONTRIBUTING.md#adding-a-meetup-to-the-site)**
+- **[Add a project to electron.atom.io/apps](CONTRIBUTING.md#adding-an-app-or-project-to-the-site)**
+- **[Add a meetup to electron.atom.io/community](CONTRIBUTING.md#adding-a-meetup-to-the-site)**
 
 ### Build
 


### PR DESCRIPTION
This updates the `README.md` to better reflect site documentation changes since `1.0`. It also adds links to the main things people may need the repository for: adding an app or meetup to the site.

It also adds information on adding a meet up to the site in `CONTRIBUTING.md`.