### PR TITLE
Drop Electron prefix from page titles

### DIFF
--- a/_pages/404.html
+++ b/_pages/404.html
@@ -1,5 +1,5 @@
 ---
-title: 404
+title: Not Found
 permalink: /404.html
 excerpt: ""
 ---

--- a/_pages/404.html
+++ b/_pages/404.html
@@ -1,5 +1,5 @@
 ---
-title: Electron 404
+title: 404
 permalink: /404.html
 excerpt: ""
 ---

--- a/_pages/404.html
+++ b/_pages/404.html
@@ -1,5 +1,5 @@
 ---
-title: Not Found
+title: Page Not Found
 permalink: /404.html
 excerpt: ""
 ---

--- a/_pages/api.md
+++ b/_pages/api.md
@@ -1,5 +1,5 @@
 ---
-title: Electron API Reference
+title: API Reference
 permalink: /docs/api/
 layout: docs
 category: ignore

--- a/_pages/apps.html
+++ b/_pages/apps.html
@@ -1,5 +1,5 @@
 ---
-title: Electron Apps
+title: Apps
 permalink: /apps/
 layout: default
 excerpt: See some of the amazing apps built on Electron.

--- a/_pages/blog.html
+++ b/_pages/blog.html
@@ -1,5 +1,5 @@
 ---
-title: Electron Blog
+title: Blog
 permalink: /blog/
 layout: default
 excerpt: All the latest news from the Electron team and community.

--- a/_pages/community.html
+++ b/_pages/community.html
@@ -1,5 +1,5 @@
 ---
-title: Electron Community
+title: Community
 permalink: /community/
 layout: default
 ---

--- a/_pages/development.md
+++ b/_pages/development.md
@@ -1,5 +1,5 @@
 ---
-title: Electron Development
+title: Development
 permalink: /docs/development/
 layout: docs
 category: ignore

--- a/_pages/docs.html
+++ b/_pages/docs.html
@@ -1,5 +1,5 @@
 ---
-title: Electron Documentation
+title: Documentation
 permalink: /docs/
 excerpt: Guides and API reference documentation for the latest Electron release.
 redirect_from:

--- a/_pages/guides.md
+++ b/_pages/guides.md
@@ -1,5 +1,5 @@
 ---
-title: Electron Guides
+title: Guides
 permalink: /docs/guides/
 redirect_from:
   - /tutorial/

--- a/_pages/releases.md
+++ b/_pages/releases.md
@@ -1,5 +1,5 @@
 ---
-title: Electron Releases
+title: Releases
 permalink: /releases/
 redirect_from: /releases.html
 layout: releases


### PR DESCRIPTION
The new Jekyll plugins at an `- Electron` suffix for SEO reasons so this pull request removes the redundant prefix.

Follow on to #248