### PR TITLE
Revise app submission re: websites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Add your app to the list by editing [_data/apps.yml](/_data/apps.yml).
 * The required fields are `name`, `website`, and `icon`. Everything else is
   optional, but recommended.
 * Your `website` can be a repository with a `README`, but please provide a destination with information about your app.
-  * You can make a free website with [GitHub Pages](pages.github.com)
+  * You can make a free website with [GitHub Pages](https://pages.github.com)
 * Your `icon` must be `256x256` pixels in size.
 * Your `icon` must be a [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics).
 * Put your `icon` in the `images/apps` folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Add your app to the list by editing [_data/apps.yml](/_data/apps.yml).
 
 * The required fields are `name`, `website`, and `icon`. Everything else is
   optional, but recommended.
-* If your app doesn't have a website, you can specify a `repository` URL instead.
+* Your `website` can be a repository with a `README`, but please provide a destination with information about your app.
+  * You can make a free website with [GitHub Pages](pages.github.com)
 * Your `icon` must be `256x256` pixels in size.
 * Your `icon` must be a [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics).
 * Put your `icon` in the `images/apps` folder.


### PR DESCRIPTION
This PR makes an update to the app submission guidelines to specify pointing to a website or repository with a `README` . 

This is to insure we don't link directly to downloads or pages with just downloads in order for users to have a bit more information before they decide to install. 

This also points people to [GitHub Pages](pages.github.com) as an option for a free website 💻 