### PR TITLE
Add spec for 16 featured apps

### DIFF
--- a/spec/featured-spec.js
+++ b/spec/featured-spec.js
@@ -1,0 +1,13 @@
+var path = require('path')
+var test = require('tape')
+var yaml = require('yamljs')
+
+test('Limit featured homepage apps to 16', function (t) {
+  t.plan(1)
+
+  var apps = yaml.load(path.join(__dirname, '..', '_data', 'apps.yml'))
+  var featuredApps = apps.filter(function (app) {
+    return app.featuredOnHomepage
+  })
+  t.equal(featuredApps.length, 16, '16 apps should be featured instead of ' + featuredApps.length)
+})


### PR DESCRIPTION
Sometimes pull requests add `featuredOnHomepage: true` in their pull requests and since we aren't adding new ones at this time, this pull request adds a spec verifying exactly 16 are featured so we know the right amount appear on http://electron.atom.io/

/cc @jlord 