### PR TITLE
Add redirect URL to FAQ

### DIFF
--- a/_docs/faq/electron-faq.md
+++ b/_docs/faq/electron-faq.md
@@ -1,9 +1,8 @@
 ---
 version: v1.2.1
 category: ignore
-permalink: /docs/faq/
-breadcrumb: FAQ
 redirect_from:
+    - /docs/faq/electron-faq/
     - /docs/v0.24.0/faq/electron-faq/
     - /docs/v0.25.0/faq/electron-faq/
     - /docs/v0.26.0/faq/electron-faq/
@@ -36,6 +35,8 @@ redirect_from:
     - /docs/v0.37.7/faq/electron-faq/
     - /docs/v0.37.8/faq/electron-faq/
     - /docs/latest/faq/electron-faq/
+permalink: /docs/faq/
+breadcrumb: FAQ
 source_url: 'https://github.com/electron/electron/blob/master/docs/faq/electron-faq.md'
 title: "Electron FAQ"
 sort_title: "electron faq"

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -178,16 +178,17 @@ function constructDocMetadata (filepath) {
   var metadata = {
     version: version,
     category: toTitleCase(pathArray[0]).replace(/Api/, 'API').replace(/Faq/, 'FAQ'),
+    redirect_from: []
   }
 
   if (metadata.category === 'FAQ') {
     metadata.category = 'ignore' // Remove breadcrumb
     metadata.permalink = '/docs/faq/'
     metadata.breadcrumb = 'FAQ'
+    metadata.redirect_from =  [ '/docs/faq/electron-faq/' ]
   }
 
   // add redirect urls for all versions prior to 1.0
-  metadata.redirect_from = []
   var allVers = config.available_versions.concat('latest')
   allVers.forEach(function (ver) {
     if (ver.match('v1.')) return


### PR DESCRIPTION
In the Electron docs the FAQ page is located at `/docs/faq/electron-faq.md`. To make the url nice and neat on the site we were adding a permalink to FAQ page of `/docs/faq`. 

This was breaking links to the FAQ from the original docs that use the path as it is in the repository. To handle this and keep our neat and short url I've added another redirect url for the page from `/docs/faq/electron-faq/`.

This fixes an issue opened in https://github.com/electron/electron/pull/5899.