### PR TITLE
Escape app descriptions

### DIFF
--- a/_includes/featured_app.html
+++ b/_includes/featured_app.html
@@ -1,5 +1,5 @@
 {% unless app.disabled %}
-<a href='{{ app.website }}' target='_blank' title='{{ app.name }} &mdash; {{ app.description | escape }}' class='featured-app'>
+<a href='{{ app.website }}' target='_blank' title='{{ app.name }} - {{ app.description | escape }}' class='featured-app'>
   <div class='featured-app-logo-wrapper'>
     <img class='featured-app-logo' src='{{ site.baseurl }}/images/apps/{{ app.icon }}' alt='{{ app.name }}'>
   </div>

--- a/_includes/featured_app.html
+++ b/_includes/featured_app.html
@@ -1,5 +1,5 @@
 {% unless app.disabled %}
-<a href='{{ app.website }}' target='_blank' title='{{ app.name }} - {{ app.description }}' class='featured-app'>
+<a href='{{ app.website }}' target='_blank' title='{{ app.name }} &mdash; {{ app.description | escape }}' class='featured-app'>
   <div class='featured-app-logo-wrapper'>
     <img class='featured-app-logo' src='{{ site.baseurl }}/images/apps/{{ app.icon }}' alt='{{ app.name }}'>
   </div>

--- a/_includes/featured_open_source_apps.html
+++ b/_includes/featured_open_source_apps.html
@@ -5,7 +5,7 @@
   {% for app in site.data.apps %}
     {% if app.featuredOpenSource %}
     <div class="featured-app-textual">
-      <a href='{{ app.website }}' target='_blank'>{{ app.name }}</a> &mdash; {{ app.description }}
+      <a href='{{ app.website }}' target='_blank'>{{ app.name }}</a> &mdash; {{ app.description | escape }}
     </div>
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
This adds `| escape` to the places where we are using `app.description` which may contain characters that break how the text is parsed. 

<img width="368" alt="screen shot 2016-06-13 at 10 54 43 am" src="https://cloud.githubusercontent.com/assets/1305617/16017617/8f62168e-3155-11e6-88ae-117a9661cd91.png">

cc @zeke @as-cii

Closes #342 