### PR TITLE
Add link to doc translations

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -50,7 +50,7 @@ layout: default
         See something that needs fixing? Propose a change on the <a href='{{ page.source_url }}'>source</a>.
         <br>
         <span class="octicon octicon-zap mr-2"></span>
-        Need a different version of the docs? See the <a href='{{ site.baseurl }}/docs/versions/'>available versions</a>.
+        Need a different version of the docs? See the <a href='{{ site.baseurl }}/docs/versions/'>available versions</a> or <a href="https://github.com/electron/electron/tree/master/docs-translations" target="_blank">community translations</a>.
         <br>
         <span class="octicon octicon-book mr-2"></span>
         Want to search all the documentation at once? See all of the <a href='{{ site.baseurl }}/docs/all'>docs on one page</a>.


### PR DESCRIPTION
I don't think we surface anywhere on the site the fact that there are some doc translations. Those translations aren't as up to date as the ones on the site but I thought it was maybe still helpful to expose? cc @zeke 

<img width="809" alt="screen shot 2016-06-29 at 1 52 31 pm" src="https://cloud.githubusercontent.com/assets/1305617/16468578/781e70a4-3e01-11e6-9cb0-40ca24e9a2e3.png">
