### PR TITLE
Style all table elements that appear in docs

### DIFF
--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -106,3 +106,23 @@
   border-radius: $border-radius;
   background-color: $main-color-subtle;
 }
+
+.docs table {
+  th {
+    text-align: left;
+    padding: $spacer2;
+  }
+
+  tr {
+    border-bottom: 1px solid $border-color;
+    text-align: left;
+
+    td {
+      padding: $spacer2;
+      line-height: 1.4;
+      font-size: 14px;
+    }
+  }
+
+  width: 100%;
+}


### PR DESCRIPTION
The docs now contain a Markdown table via http://electron.atom.io/docs/api/app-locales/

This pull request styles all `<table>` elements under a `.docs` class so that they get a nicer styling that mirrors the other pages.

| Before | After |
| --- | --- |
|  <img width="831" alt="screen shot 2016-07-08 at 11 55 06 am" src="https://cloud.githubusercontent.com/assets/671378/16698488/54e2cd7a-4503-11e6-958c-fba4eac94484.png"> |  <img width="816" alt="screen shot 2016-07-08 at 11 54 39 am" src="https://cloud.githubusercontent.com/assets/671378/16698482/4cadb2aa-4503-11e6-8b91-309de2cee39e.png"> | 

