### PR TITLE
Add redirect for old locales doc path

### DIFF
--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -182,6 +182,9 @@ function constructDocMetadata (filepath) {
     redirect_from: []
   }
 
+  // add redirect for old filename
+  if (pathArray === 'locales.md') metadata.redirect_from = ['/docs/api/app-locales/']
+
   if (metadata.category === 'FAQ') {
     metadata.category = 'ignore' // Remove breadcrumb
     metadata.permalink = '/docs/faq/'


### PR DESCRIPTION
This adds a special redirect for the locales doc page which has been renamed and therefore will have a new path when the next version of Electron ships.

Was thinking that we needed to wait but actually this can be merged now and won't effect anything.

Closes https://github.com/electron/electron.atom.io/issues/374