### PR TITLE
Remove permalink for FAQ

### DIFF
--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -183,7 +183,6 @@ function constructDocMetadata (filepath) {
 
   if (metadata.category === 'FAQ') {
     metadata.category = 'ignore' // Remove breadcrumb
-    metadata.permalink = '/docs/faq/'
     metadata.breadcrumb = 'FAQ'
     metadata.redirect_from =  [ '/docs/faq/electron-faq/' ]
   }


### PR DESCRIPTION
When the next version of docs ships the FAQ will live at this location so we don't need to use the permalink anymore ✨ 

cc @zeke I think this is all we need to change to prep for that update?