### PR TITLE
Update email address in Electron announcement post

### DIFF
--- a/_posts/2015-04-23-electron.md
+++ b/_posts/2015-04-23-electron.md
@@ -19,7 +19,7 @@ So far, individual developers, early-stage startups, and large companies have bu
 
 Check out the new [electron.atom.io][electron] to see more of the apps people have built on Electron or take a look at the [docs][docs] to learn more about what else you can make.
 
-If you've already gotten started, we'd love to chat with you about the apps you're building on Electron. Email [atom@github.com](mailto:atom@github.com?Subject=Electron) to tell us more. You can also follow the new [@ElectronJS](https://twitter.com/electronjs) Twitter account to stay connected with the project.
+If you've already gotten started, we'd love to chat with you about the apps you're building on Electron. Email [electron@github.com](mailto:electron@github.com?Subject=Electron) to tell us more. You can also follow the new [@ElectronJS](https://twitter.com/electronjs) Twitter account to stay connected with the project.
 
 :zap: :blue_heart: :electric_plug:
 


### PR DESCRIPTION
Saw the old email address in the old post when I was linking it for a Discuss member. I figured updating it would be good.