### PR TITLE
Fix FAQ breadcrumb

### DIFF
--- a/_docs/faq.md
+++ b/_docs/faq.md
@@ -1,7 +1,8 @@
 ---
 version: v1.2.7
-category: faq.md
+category: ignore
 redirect_from:
+    - /docs/faq/electron-faq/
     - /docs/v0.24.0/faq/
     - /docs/v0.25.0/faq/
     - /docs/v0.26.0/faq/
@@ -34,6 +35,7 @@ redirect_from:
     - /docs/v0.37.7/faq/
     - /docs/v0.37.8/faq/
     - /docs/latest/faq/
+breadcrumb: FAQ
 source_url: 'https://github.com/electron/electron/blob/master/docs/faq.md'
 title: "Electron FAQ"
 sort_title: "electron faq"

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -175,7 +175,11 @@ function constructSourceUrl (path) {
 }
 
 function constructDocMetadata (filepath) {
-  var pathArray = filepath.split('/').splice(2, 2)
+  var pathArray
+  // FAQ only doc in root dir
+  if (filepath.match('faq.md')) pathArray = ['faq']
+  else pathArray = filepath.split('/').splice(2, 2)
+
   var metadata = {
     version: version,
     category: toTitleCase(pathArray[0]).replace(/Api/, 'API').replace(/Faq/, 'FAQ'),


### PR DESCRIPTION
We moved the FAQ to the root which messed up the doc generator because it previously didn't expect anything in the root. 

This PR just explicitly looks for the FAQ. If our structure gets more complex in the future we can rethink this bit of logic. 

@zeke this is to merge into your https://github.com/electron/electron.atom.io/pull/378

<img width="622" alt="screen shot 2016-07-13 at 9 29 11 am" src="https://cloud.githubusercontent.com/assets/1305617/16811828/105a279a-48df-11e6-85d5-68d0a391d1cc.png">
<img width="625" alt="screen shot 2016-07-13 at 9 47 07 am" src="https://cloud.githubusercontent.com/assets/1305617/16811829/1087fd46-48df-11e6-9a0a-8d9dda7b6315.png">
