### PR TITLE
apply OS label style to H4 in addition to H3

### DIFF
--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -82,7 +82,9 @@
 
 // platform label, e.g. [OS X]
 .docs h3 code > em,
-.docs h3 > em {
+.docs h3 > em,
+.docs h4 code > em,
+.docs h4 > em {
     padding: .1em .4em;
     vertical-align: middle;
     font-size: .66em;


### PR DESCRIPTION
These styles regressed when we updated the styleguide and docs to use H4-level headings for things like Events and Instance Methods.

![screen shot 2016-07-27 at 2 07 03 pm](https://cloud.githubusercontent.com/assets/2289/17192500/a7fccd94-5403-11e6-93d0-0cdfaa10b621.png)


👀  @kevinsawicki 