### PR TITLE
Helpers for creating monthly roundups

### DIFF
--- a/_data/apps.yml
+++ b/_data/apps.yml
@@ -1367,6 +1367,7 @@
     - "productivity"
     - "paws"
   icon: "paws-for-trello.png"
+# July 2016
 -
   name: "Yout"
   description: "Yout Player is the new way to watch your playlists from youtube on desktop."
@@ -1522,6 +1523,7 @@
       - "magnet"
   license: "GPLv3"
   icon: "electorrent.png"
+# August 2016
 -
   name: "Code RPGify"
   description: "RPG style coding application"

--- a/_drafts/roundup.md
+++ b/_drafts/roundup.md
@@ -1,0 +1,27 @@
+---
+title:
+author:
+---
+
+Here's the latest roundup apps, upcoming meetups, tools, videos, etc from the community.
+
+---
+
+This site is updated with new [apps](http://electron.atom.io/apps) and [meetups](http://electron.atom.io/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](http://electron.atom.io/feed.xml).
+
+If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
+
+### New Apps
+
+{: .table .table-ruled .table-full-width .table-with-spacious-first-column .mb-7}
+|     |     |    |
+| --- | --- | -- |
+| <img src="/images/apps/" width="50"> | []() | Description |
+
+
+### New Meetups
+
+{: .table .table-ruled .table-full-width .table-with-spacious-first-column .mb-7}
+|     |    |
+| --- | -- |
+| []() | Description |


### PR DESCRIPTION
To make creating the monthly roundups easier I had this idea—

(Note: For this month’s post I went through the PRs, labeled the ones that were app additions thinking doing a search through that list would be the easiest way to see what was added when.)

- When a fresh :tulip: roundup is cut the author should go into `_data/apps.yml` and add a header for the **new** month :calendar: 
- Then create the post based on everything in the list up until the **previous** month header. 

This will be much easier than going back and forth copy :spaghetti:  from PRs. 