### PR TITLE
Add color to links within <code>

### DIFF
--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -61,4 +61,8 @@
   hr:first-of-type {
     display: none;
   }
+
+  a code {
+    color: $main-link-color;
+  }
 }


### PR DESCRIPTION
When previewing #410 I noticed that links that were wrapping `<code>` tags didn't get any new style so it was hard to tell they were links at all. This gives them the same colors as text links and you can now 👀 them. 

| Before | After |
|---|---|
| ![img](https://cloud.githubusercontent.com/assets/1305617/17490136/3c59cfea-5d56-11e6-8ff3-e7efaa191459.png) | ![img2](https://cloud.githubusercontent.com/assets/1305617/17490133/36943712-5d56-11e6-89df-ca9ef45c2857.png) |

---

<img width="858" alt="screen shot 2016-08-08 at 10 53 09 am" src="https://cloud.githubusercontent.com/assets/1305617/17490158/57600a8e-5d56-11e6-9d10-9a2549fb3738.png">



