### PR TITLE
Style platform labels in lists

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -60,3 +60,14 @@ layout: default
 
   </div>
 </section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var ems = document.querySelectorAll('em')
+    Array.prototype.forEach.call(ems, function (em) {
+      if (em.textContent === 'macOS' || em.textContent === 'Linux' || em.textContent === 'Windows') {
+        em.classList.add('platform-label')
+      }
+    })
+  })
+</script>

--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -90,7 +90,6 @@
     vertical-align: middle;
     font-size: .66em;
     font-weight: 300;
-    text-transform: uppercase;
     font-style: normal;
     color: $main-bg-color;
     border-radius: $border-radius;

--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -84,7 +84,8 @@
 .docs h3 code > em,
 .docs h3 > em,
 .docs h4 code > em,
-.docs h4 > em {
+.docs h4 > em,
+.docs li em {
     padding: .1em .4em;
     vertical-align: middle;
     font-size: .66em;

--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -85,7 +85,7 @@
 .docs h3 > em,
 .docs h4 code > em,
 .docs h4 > em,
-.docs li em {
+.docs .platform-label {
     padding: .1em .4em;
     vertical-align: middle;
     font-size: .66em;


### PR DESCRIPTION
Platform labels were not getting styled anywhere other than in method/event headers. There are platform labels, however, in the lists of arguments for methods and those need to be styled.

There _shouldn't_ be anything else we're using `em` for in a list in the docs (I think??) so what I have now may be fine: `.docs li em` but I'd like @simurai's thoughts. Should it be more specific? 

🔗 [to live doc](http://localhost:4000/docs/api/auto-updater/#autoupdatersetfeedurlurl-requestheaders)

![before](https://cloud.githubusercontent.com/assets/671378/17493922/3b20fbba-5d67-11e6-9376-e87c0a8c09fd.png)

![after](https://cloud.githubusercontent.com/assets/1305617/17496608/eed8f68e-5d72-11e6-8f43-0d450f5d562b.png)

Fixes #419 
Fixes #421