### PR TITLE
Remove incorrect string template styles

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -63,10 +63,19 @@ layout: default
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
+    // All ems with platform content should be styled as platform label
     var ems = document.querySelectorAll('em')
     Array.prototype.forEach.call(ems, function (em) {
       if (em.textContent === 'macOS' || em.textContent === 'Linux' || em.textContent === 'Windows') {
         em.classList.add('platform-label')
+      }
+    })
+
+    // Override incorrect styling of string templates
+    var sts = document.querySelectorAll('.err')
+    Array.prototype.forEach.call(sts, function (st) {
+      if (st.textContent === '`') {
+        st.classList.remove('err')
       }
     })
   })


### PR DESCRIPTION
This adds some JS to remove the incorrectly applied syntax highlighting style added by the default highlighter in Jekyll. 


**Before**
<img width="480" alt="screen shot 2016-08-11 at 10 01 37 am" src="https://cloud.githubusercontent.com/assets/1305617/17597472/c1d86c02-5faa-11e6-8c1e-a217d9fd158e.png">
**After**
<img width="447" alt="screen shot 2016-08-11 at 10 01 43 am" src="https://cloud.githubusercontent.com/assets/1305617/17597473/c1feed1e-5faa-11e6-8d9a-61ac7fc7978b.png">



Fixes #402 

