### PR TITLE
Update electron-prebuilt → electron on releases page

### DIFF
--- a/_layouts/releases.html
+++ b/_layouts/releases.html
@@ -19,10 +19,10 @@ layout: default
 <section class='page-section'>
   <div class='container-narrow'>
     <h3>Tip: Use Electron from the command line</h3>
-    <p>Installing the <code>electron-prebuilt</code> module as a development dependency in your project will let you use Electron from the command line at specific versions. More information on the <a href="https://github.com/electron-userland/electron-prebuilt" target="_blank">module's repository</a>.</p>
+    <p>Installing the <code>electron</code> module as a development dependency in your project will let you use Electron from the command line at specific versions. More information on the <a href="https://github.com/electron-userland/electron-prebuilt" target="_blank">module's repository</a>.</p>
 
     <figure class="highlight highlight-dark text-left my-4">
-      <pre><code>$ npm install --save-dev electron-prebuilt
+      <pre><code>$ npm install --save-dev electron
 <span class="c1"># Launch from inside your project's directory:</span>
 $ ./node_modules/.bin/electron .</code></pre>
     </figure>


### PR DESCRIPTION
This updates a section on the releases page to now use `electron` as the module name rather than `electron-prebuilt`. 

[Blog post on the change](http://electron.atom.io/blog/2016/08/16/npm-install-electron) 📝 

<img width="908" alt="screen shot 2016-08-16 at 1 11 15 pm" src="https://cloud.githubusercontent.com/assets/1305617/17714111/31705d20-63b3-11e6-814e-bdba0704d168.png">