### PR TITLE
Added website attribute to Ionic Creator & TwitchAlerts

### DIFF
--- a/_data/apps.yml
+++ b/_data/apps.yml
@@ -1591,6 +1591,7 @@
 -
   name: "Ionic Creator"
   description: "Build amazing mobile apps, faster."
+  website: "https://github.com/Meadowcottage/Ionic-Creator"
   repository: "https://github.com/Meadowcottage/Ionic-Creator"
   keywords:
     - "Electron"
@@ -1602,6 +1603,7 @@
 -
   name: "TwitchAlerts"
   description: "Keep your viewers happy with beautiful alerts and notifications!"
+  website: "https://github.com/Meadowcottage/TwitchAlerts"
   repository: "https://github.com/Meadowcottage/TwitchAlerts"
   keywords:
     - "Electron"


### PR DESCRIPTION
A quick fix suggested by @amitmerchant1990 to add the website attribute as at the moment the link doesn't go anywhere apart from the current apps page.