### PR TITLE
On apps page use repository URL if there is no website

### DIFF
--- a/_includes/featured_app.html
+++ b/_includes/featured_app.html
@@ -1,5 +1,5 @@
 {% unless app.disabled %}
-<a href='{{ app.website }}' target='_blank' title='{{ app.name }} - {{ app.description | escape }}' class='featured-app'>
+<a href='{{ app.website | default: app.repository }}' target='_blank' title='{{ app.name }} - {{ app.description | escape }}' class='featured-app'>
   <div class='featured-app-logo-wrapper'>
     <img class='featured-app-logo' src='{{ site.baseurl }}/images/apps/{{ app.icon }}' alt='{{ app.name }}'>
   </div>

--- a/_includes/featured_open_source_apps.html
+++ b/_includes/featured_open_source_apps.html
@@ -5,7 +5,7 @@
   {% for app in site.data.apps %}
     {% if app.featuredOpenSource %}
     <div class="featured-app-textual">
-      <a href='{{ app.website }}' target='_blank'>{{ app.name }}</a> &mdash; {{ app.description | escape }}
+      <a href='{{ app.website | default: app.repository }}' target='_blank'>{{ app.name }}</a> &mdash; {{ app.description | escape }}
     </div>
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
As @amitmerchant1990 pointed out https://github.com/electron/electron.atom.io/pull/424#issuecomment-240324301, not all apps provided a `website` so the linked image just refreshed the page.

This PR updates the template to use the `repository` URL if no `website` is provided. 

Thanks @muan for this ProTip™ ⭐ `{{ app.website | default: app.repository }}`