### PR TITLE
Show process in API Reference table

### DIFF
--- a/_pages/api.md
+++ b/_pages/api.md
@@ -8,13 +8,14 @@ breadcrumb: API
 
 <h2 class="docs-heading pb-3 mb-3"><span class="mega-octicon octicon-gear pr-3"></span>API Reference</h2>
 
-<table class="table table-ruled table-full-width table-with-spacious-first-column">
+<table class="table table-ruled table-full-width table-with-spacious-second-column">
 
 {% assign docs = site.docs | sort: 'sort_title' %}
 {% for doc in docs %}
   {% if doc.category == 'API' %}
     <tr>
       <td><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></td>
+      <td>{{ site.data.processes[doc.title] }}</td>
       <td>{{ doc.excerpt }}</td>
     </tr>
   {% endif %}

--- a/_pages/api.md
+++ b/_pages/api.md
@@ -9,13 +9,16 @@ breadcrumb: API
 <h2 class="docs-heading pb-3 mb-3"><span class="mega-octicon octicon-gear pr-3"></span>API Reference</h2>
 
 <table class="table table-ruled table-full-width table-with-spacious-second-column">
+<tr>
+  <th>API</th><th>Processes</th><th>Description</th>
+</tr>
 
 {% assign docs = site.docs | sort: 'sort_title' %}
 {% for doc in docs %}
   {% if doc.category == 'API' %}
     <tr>
       <td><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></td>
-      <td>{{ site.data.processes[doc.title] }}</td>
+      <td>{{ site.data.processes[doc.title] | replace: 'Process', '' | replace: 'Processes', '' }}</td>
       <td>{{ doc.excerpt }}</td>
     </tr>
   {% endif %}

--- a/_sass/_basecoat-tables.scss
+++ b/_sass/_basecoat-tables.scss
@@ -22,3 +22,10 @@
     white-space: nowrap;
   }
 }
+
+.table-with-spacious-second-column td:nth-child(2) {
+  @include breakpoint(md) {
+    padding-right: $spacer5;
+    white-space: nowrap;
+  }
+}

--- a/_sass/_basecoat-tables.scss
+++ b/_sass/_basecoat-tables.scss
@@ -16,13 +16,7 @@
   font-size: 14px;
 }
 
-.table-with-spacious-first-column td:first-child {
-  @include breakpoint(md) {
-    padding-right: $spacer5;
-    white-space: nowrap;
-  }
-}
-
+.table-with-spacious-first-column td:first-child,
 .table-with-spacious-second-column td:nth-child(2) {
   @include breakpoint(md) {
     padding-right: $spacer5;


### PR DESCRIPTION
This adds the process/s name in the table of Electron APIs at [electron.atom.io/docs/api](http://electron.atom.io/docs/api).

I added a class to fit it all in there but don't know if it should be done in a different way so pinging @simurai for thoughts ✨ 

| Before | After |
| --- | --- | 
|<img width="911" alt="screen shot 2016-08-19 at 2 07 24 pm" src="https://cloud.githubusercontent.com/assets/1305617/17824354/4e28d734-6616-11e6-8fa1-2e804024bd4a.png">|<img width="1062" alt="screen shot 2016-08-18 at 1 33 20 pm" src="https://cloud.githubusercontent.com/assets/1305617/17824338/2f3bc85e-6616-11e6-9cc7-3f7aa111cc7f.png">|

There is an After-After also... The "Process" and "Processes" text looks repetitive so I took it out but that meant needing to add table headers. What's your preference @simurai?

| After-After |
| --- | 
| <img width="918" alt="screen shot 2016-08-19 at 2 13 52 pm" src="https://cloud.githubusercontent.com/assets/1305617/17824548/85dea87e-6617-11e6-982e-f135c8ec63b9.png">|