### PR TITLE
Add roundup blog post helper

### DIFF
--- a/lib/roundup-helper.js
+++ b/lib/roundup-helper.js
@@ -1,0 +1,21 @@
+var fs = require('fs')
+var yaml = require('yamljs')
+
+// Usage: node lib/roundup-helper.js <RoundupMonth> <PostMonth> <Year>
+// Returns: Markdown table rows to be copy and pasted into blog post
+// Example for August roundup: node lib/roundup-helper.js August September 2016
+// Example post: http://electron.atom.io/blog/2016/09/06/august-2016-roundup
+var args = process.argv.slice(2)
+if (!args[3]) args.push(new Date().getFullYear())
+
+var yamlString = fs.readFileSync('_data/apps.yml').toString()
+var roundupMonth = yamlString.split(`# ${args[0]} ${args[2]}`)[1].split(`# ${args[1]} ${args[2]}`)[0]
+var apps = yaml.parse(roundupMonth)
+var rows = ''
+
+apps.forEach(function (app) {
+  app.description = app.description.replace('.', '').replace('!', '')
+  return rows += `| <img src='/images/apps/${app.icon}' width='50'> | [${app.name}](${app.website || app.repository}) | ${app.description} |\n`
+})
+
+console.log(rows)

--- a/lib/roundup-helper.js
+++ b/lib/roundup-helper.js
@@ -5,6 +5,7 @@ var yaml = require('yamljs')
 // Returns: Markdown table rows to be copy and pasted into blog post
 // Example for August roundup: node lib/roundup-helper.js August September 2016
 // Example post: http://electron.atom.io/blog/2016/09/06/august-2016-roundup
+// Note: A current month comment must be added to _data/apps.yml before using 
 var args = process.argv.slice(2)
 if (!args[3]) args.push(new Date().getFullYear())
 


### PR DESCRIPTION
This adds a little helper for generating markdown table rows based on apps in `_data/apps.yml` so that there is much less copypasta needed to do a roundup post. Automation! 💥 

This will mostly be used by myself and/or Electron team when working on these types of posts ✏️ 

![screen shot 2016-09-06 at 4 07 09 pm](https://cloud.githubusercontent.com/assets/1305617/18294138/005c783c-744c-11e6-94b3-b3f650139a3e.png)

[Example roundup post](http://electron.atom.io/blog/2016/09/06/august-2016-roundup)

cc @zeke @kevinsawicki 