### PR TITLE
Syntax highlighting fixes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,8 @@
 
   {% seo %}
   {% feed_meta %}
-  
+
+  <script src="{{ site.baseurl }}/js/index.js"></script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -60,23 +60,3 @@ layout: default
 
   </div>
 </section>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    // All ems with platform content should be styled as platform label
-    var ems = document.querySelectorAll('em')
-    Array.prototype.forEach.call(ems, function (em) {
-      if (em.textContent === 'macOS' || em.textContent === 'Linux' || em.textContent === 'Windows') {
-        em.classList.add('platform-label')
-      }
-    })
-
-    // Override incorrect styling of string templates
-    var sts = document.querySelectorAll('.err')
-    Array.prototype.forEach.call(sts, function (st) {
-      if (st.textContent === '`') {
-        st.classList.remove('err')
-      }
-    })
-  })
-</script>

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -4,7 +4,7 @@ layout: default
 ---
 
   <script src="{{ site.baseurl }}/js/vendor/ua-parser-js-0.7.10.js"></script>
-  <script src="{{ site.baseurl }}/js/index.js"></script>
+  <script src="{{ site.baseurl }}/js/update-download-link.js"></script>
 
   <div class="jumbotron jumbotron-home text-center">
     <div class="container">

--- a/_sass/_highlight.scss
+++ b/_sass/_highlight.scss
@@ -2,7 +2,7 @@
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { color: #000000; font-weight: bold } /* Keyword */
-.highlight .o { color: #000000; font-weight: bold } /* Operator */
+// .highlight .o { color: #000000; font-weight: bold } /* Operator */
 .highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */
 .highlight .cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
 .highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
@@ -17,7 +17,7 @@
 .highlight .gs { font-weight: bold } /* Generic.Strong */
 .highlight .gu { color: #aaaaaa } /* Generic.Subheading */
 .highlight .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight .kc { color: #000000; font-weight: bold } /* Keyword.Constant */
+.highlight .kc { color: #000000; } /* Keyword.Constant */
 .highlight .kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
 .highlight .kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
 .highlight .kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
@@ -33,7 +33,7 @@
 .highlight .ni { color: #800080 } /* Name.Entity */
 .highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
 .highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
-.highlight .nl { color: #990000; font-weight: bold } /* Name.Label */
+// .highlight .nl { color: #990000; font-weight: bold } /* Name.Label */
 .highlight .nn { color: #555555 } /* Name.Namespace */
 .highlight .nt { color: #000080 } /* Name.Tag */
 .highlight .nv { color: #008080 } /* Name.Variable */

--- a/js/index.js
+++ b/js/index.js
@@ -1,30 +1,25 @@
-var updateDownloadLink = function () {
-  var platform = uaParserJs().os.name
-  var releaseServer = 'https://electron-api-demos.githubapp.com/updates/'
-  var assetName
-  var osLabel
-
-  if (/mac/i.test(platform)) {
-    assetName = 'electron-api-demos-mac.zip'
-    osLabel = 'Mac'
-  } else if (/windows/i.test(platform)) {
-    assetName = 'ElectronAPIDemosSetup.exe'
-    osLabel = 'Windows'
-  } else if (/ubuntu|linux/i.test(platform)) {
-    assetName = 'electron-api-demos-linux.zip'
-    osLabel = 'Linux'
-  } else {
-    return
-  }
-
-  document.querySelector('#download-latest-release')
-    .setAttribute('href', releaseServer + assetName)
-
-  document.querySelector('#download-latest-release .label')
-    .textContent = 'Download for ' + osLabel
-
-  document.querySelector('#download-alternatives')
-    .style.display = 'inline-block'
+// All ems with platform content should be styled as platform label
+function fixPlatformLabels () {
+  var ems = document.querySelectorAll('em')
+  Array.prototype.forEach.call(ems, function (em) {
+    if (em.textContent === 'macOS' || em.textContent === 'Linux' || em.textContent === 'Windows') {
+      em.classList.add('platform-label')
+    }
+  })
 }
 
-document.addEventListener('DOMContentLoaded', updateDownloadLink)
+// Override incorrect styling of string templates and colons in objects
+function fixSyntaxHighlighting () {
+  var sts = document.querySelectorAll('.err')
+  Array.prototype.forEach.call(sts, function (st) {
+    console.log('wtf')
+    if (st.textContent === '`' || st.textContent === ':') {
+      st.classList.remove('err')
+    }
+  })
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  fixPlatformLabels()
+  fixSyntaxHighlighting()
+})

--- a/js/update-download-link.js
+++ b/js/update-download-link.js
@@ -1,0 +1,30 @@
+var updateDownloadLink = function () {
+  var platform = uaParserJs().os.name
+  var releaseServer = 'https://electron-api-demos.githubapp.com/updates/'
+  var assetName
+  var osLabel
+
+  if (/mac/i.test(platform)) {
+    assetName = 'electron-api-demos-mac.zip'
+    osLabel = 'Mac'
+  } else if (/windows/i.test(platform)) {
+    assetName = 'ElectronAPIDemosSetup.exe'
+    osLabel = 'Windows'
+  } else if (/ubuntu|linux/i.test(platform)) {
+    assetName = 'electron-api-demos-linux.zip'
+    osLabel = 'Linux'
+  } else {
+    return
+  }
+
+  document.querySelector('#download-latest-release')
+    .setAttribute('href', releaseServer + assetName)
+
+  document.querySelector('#download-latest-release .label')
+    .textContent = 'Download for ' + osLabel
+
+  document.querySelector('#download-alternatives')
+    .style.display = 'inline-block'
+}
+
+document.addEventListener('DOMContentLoaded', updateDownloadLink)


### PR DESCRIPTION
This PR shuffles some javascript around so that the syntax-highlighting fixes are applied on all pages instead of just the docs pages. It also disables/removes some styles that make javascript look weird:

Before | After
--- | ---
<img width="266" alt="screen shot 2016-09-26 at 10 34 34 am" src="https://cloud.githubusercontent.com/assets/2289/18845195/83f33094-83d5-11e6-8267-5c44c4d994c0.png"> | <img width="262" alt="screen shot 2016-09-26 at 10 30 41 am" src="https://cloud.githubusercontent.com/assets/2289/18845206/8d68d2f0-83d5-11e6-8b22-24ccd1c0a7a2.png">

#491 includes some affected snippets, so it would be nice to land this first.

👀 @jlord @kevinsawicki 
