### PR TITLE
Structures

### DIFF
--- a/_pages/api.md
+++ b/_pages/api.md
@@ -16,11 +16,13 @@ breadcrumb: API
 {% assign docs = site.docs | sort: 'sort_title' %}
 {% for doc in docs %}
   {% if doc.category == 'API' %}
-    <tr>
-      <td><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></td>
-      <td>{{ site.data.processes[doc.title] | replace: 'Process', '' | replace: 'Processes', '' }}</td>
-      <td>{{ doc.excerpt }}</td>
-    </tr>
+    {% unless doc.source_url contains '/structures/' %}
+      <tr>
+        <td><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></td>
+        <td>{{ site.data.processes[doc.title] | replace: 'Process', '' | replace: 'Processes', '' }}</td>
+        <td>{{ doc.excerpt }}</td>
+      </tr>
+    {% endunless %}
   {% endif %}
 {% endfor %}
 </table>

--- a/_pages/api.md
+++ b/_pages/api.md
@@ -15,14 +15,11 @@ breadcrumb: API
 
 {% assign docs = site.docs | sort: 'sort_title' %}
 {% for doc in docs %}
-  {% if doc.category == 'API' %}
-    {% unless doc.source_url contains '/structures/' %}
-      <tr>
-        <td><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></td>
-        <td>{{ site.data.processes[doc.title] | replace: 'Process', '' | replace: 'Processes', '' }}</td>
-        <td>{{ doc.excerpt }}</td>
-      </tr>
-    {% endunless %}
-  {% endif %}
+  {% if doc.category != 'API' %}{% continue %}{% endif %}
+  {% if doc.source_url contains '/structures/' %}{% continue %}{% endif %}
+  <tr>
+    <td><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></td>
+    <td>{{ site.data.processes[doc.title] | replace: 'Process', '' | replace: 'Processes', '' }}</td>
+    <td>{{ doc.excerpt }}</td>
+  </tr>
 {% endfor %}
-</table>

--- a/lib/doc-links.js
+++ b/lib/doc-links.js
@@ -8,7 +8,7 @@ var path = require('path')
 // to other pages within the docs (relative links,
 // rather than external).
 //
-// We're looking for these patterns in trandional markdown link syntax:
+// We're looking for these patterns in traditional markdown link syntax:
 // - [words](../abc/abc.md)
 // - [words](../abc/abc)
 // - [words](abc)
@@ -83,7 +83,12 @@ module.exports = function fixLinks (dir, version, callback) {
 
       if (href.match(/\.md/ig)) {
         var newLink = href.replace(/\.md/ig, '')
-        if (newLink.indexOf('../') > -1) {
+        if (newLink.match('structures')) {
+          newLink = 'http://' + path.join(baseUrl, 'api', newLink).split(path.sep).join('/')
+          if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
+          else newMdLink = bracket + newLink
+          return newMdLink
+        } else if (newLink.indexOf('../') > -1) {
           newLink = 'http://' + path.join(baseUrl, newLink.replace('../', '')).split(path.sep).join('/')
           if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
           else newMdLink = bracket + newLink

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -43,13 +43,15 @@ var fetchDocs = module.exports = function fetchDocs (_settings, callback) {
     if (err) throw err
     if (resp.statusCode !== 200) throw Error(resp.statusCode + ' response from ' + latest)
     tarballUrl = body.tarball_url
+    version = tarballUrl.split('/').pop()
 
-    // override tarball for testing out branches:
+    // overrides for testing
+    // a branch:
     // tarballUrl = 'https://api.github.com/repos/electron/electron/tarball/master'
+    // a specific commit:
     // tarballUrl = 'https://github.com/electron/electron/archive/ba49fbc8ba2fac0b72b1530f2ce46c1cd3110620.tar.gz'
     // version = 'v1.4.1'
 
-    version = tarballUrl.split('/').pop()
     settings.version = version
     return updateVersions(callback)
   })

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -46,6 +46,8 @@ var fetchDocs = module.exports = function fetchDocs (_settings, callback) {
 
     // override tarball for testing out branches:
     // tarballUrl = 'https://api.github.com/repos/electron/electron/tarball/master'
+    // tarballUrl = 'https://github.com/electron/electron/archive/ba49fbc8ba2fac0b72b1530f2ce46c1cd3110620.tar.gz'
+    // version = 'v1.4.1'
 
     version = tarballUrl.split('/').pop()
     settings.version = version


### PR DESCRIPTION
Fixes #509 

This updates the markdown parser to rewrite links to the new files in `/docs/api/structures`.

![screen shot 2016-10-04 at 1 50 38 pm](https://cloud.githubusercontent.com/assets/2289/19092140/42bc3c22-8a3a-11e6-946b-e74b25ac4e35.png)

cc @MarshallOfSound 

