### PR TITLE
Encode pipes so they don't become tables

### DIFF
--- a/_docs/api/net.md
+++ b/_docs/api/net.md
@@ -101,7 +101,7 @@ The `net` module has the following methods:
 
 ### `net.request(options)`
 
-* `options` (Object | String) - The `ClientRequest` constructor options.
+* `options` (Object &#124; String) - The `ClientRequest` constructor options.
 
 Returns `ClientRequest`
 
@@ -119,7 +119,7 @@ interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#
 
 ### `new ClientRequest(options)`
 
-* `options` (Object | String) - If `options` is a String, it is interpreted as
+* `options` (Object &#124; String) - If `options` is a String, it is interpreted as
   the request URL. If it is an object, it is expected to fully specify an HTTP
   request via the following properties:
   * `method` String (optional) - The HTTP request method. Defaults to the GET
@@ -270,7 +270,7 @@ before first write. Trying to call it after the first write will throw an error.
 
 #### `request.write(chunk[, encoding][, callback])`
 
-* `chunk` (String | Buffer) - A chunk of the request body's data. If it is a
+* `chunk` (String &#124; Buffer) - A chunk of the request body's data. If it is a
   string, it is converted into a Buffer using the specified encoding.
 * `encoding` String (optional) - Used to convert string chunks into Buffer
   objects. Defaults to 'utf-8'.
@@ -288,7 +288,7 @@ it is not allowed to add or remove a custom header.
 
 #### `request.end([chunk][, encoding][, callback])`
 
-* `chunk` (String | Buffer) (optional)
+* `chunk` (String &#124; Buffer) (optional)
 * `encoding` String (optional)
 * `callback` Function (optional)
 

--- a/lib/doc-links.js
+++ b/lib/doc-links.js
@@ -127,7 +127,7 @@ module.exports = function fixLinks (dir, version, callback) {
     // https://github.com/electron/electron.atom.io/issues/556
     content = content
       .split('\n')
-      .map(line => line.match(/^\* `/) ? line.replace(/ \| /g, ' &#124; ') : line)
+      .map(line => line.match(/^\s*\* `/) ? line.replace(/ \| /g, ' &#124; ') : line)
       .join('\n')
 
     writeLinkstoFile(file, content)

--- a/lib/doc-links.js
+++ b/lib/doc-links.js
@@ -122,6 +122,14 @@ module.exports = function fixLinks (dir, version, callback) {
     oldLinks.forEach(function (oldLink, i) {
       content = content.replace(oldLink, newLinks[i])
     })
+
+    // Work around kramdown's misinterpretation of pipe as a table header
+    // https://github.com/electron/electron.atom.io/issues/556
+    content = content
+      .split('\n')
+      .map(line => line.match(/^\* `/) ? line.replace(/ \| /g, ' &#124; ') : line)
+      .join('\n')
+
     writeLinkstoFile(file, content)
   }
 


### PR DESCRIPTION
I pinged the GitHub Pages team about this one. @parkr points out that there are some deficiencies in the [kramdown](https://github.com/gettalong) markdown parser used by Jekyll:

> It uses regular expressions to match things. So if you have `|` then 10 lines later a `|`, the content in between may be considered a table.

It would be nice to land a fix for this in kramdown itself, but here is an interim fix. The line-by-line technique is used to match a specific pattern and avoid encoding pipes elsewhere in our markdown files.

cc @gettalong, maintainer of kramdown
cc @aliib, who reported the issue
cc @kevinsawicki, pull-request-reviewer extraordinaire

Fixes #556 