### PR TITLE
support redirects for renamed docs

### DIFF
--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -207,6 +207,15 @@ function constructDocMetadata (filepath) {
       .replace('docs/', `docs/${ver}/`).replace('.md', '/'))
   })
 
+  // redirect files that got renamed
+  const redirects = [
+    {old: '/docs/api/web-view-tag', new: '/docs/api/webview-tag'},
+  ]
+
+  redirects.forEach(redirect => {
+    if (filepath.match(redirect.new)) metadata.redirect_from.push(redirect.old)
+  })
+
   return metadata
 }
 


### PR DESCRIPTION
This PR exists in anticipation of a rename in electron/electron:

`web-view-tag.md` 👉 `webview-tag.md`