### PR TITLE
Remove Whatsie

### DIFF
--- a/_data/apps.yml
+++ b/_data/apps.yml
@@ -956,18 +956,6 @@
   license: "Apache 2.0"
   icon: "etcher.png"
 -
-  name: "Whatsie"
-  description: "Simple & beautiful desktop client for WhatsApp Web"
-  website: "https://whatsie.chat/"
-  repository: "https://github.com/Aluxian/Whatsie"
-  keywords:
-    - "whatsapp"
-    - "desktop"
-    - "messenger"
-    - "chat"
-  license: "MIT"
-  icon: "whatsie.png"
--
   name: "STAMP"
   description: "Move tracks and playlists across various streaming services"
   website: "https://freeyourmusic.com/"


### PR DESCRIPTION
The website says: "Whatsie is not available anymore.
Please use the official client."