### PR TITLE
lock the github-userland-reports dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "cheerio": "^0.20.0",
     "electron-apps": "github:electron/electron-apps",
-    "electron-userland-reports": "^1.5.0",
+    "electron-userland-reports": "1.5.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-link-checker": "^0.1.0",


### PR DESCRIPTION
This will prevent any regressions from new reports that don't yet have a companion template in the website repo.