### PR TITLE
Fix multiple links on a line

### DIFF
--- a/_docs/api/browser-window.md
+++ b/_docs/api/browser-window.md
@@ -1026,7 +1026,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](http://electron.atom.io/docs/api/structures/upload-raw-data) &#124; [UploadFil)
+  * `postData` ([UploadRawData](http://electron.atom.io/docs/api/structures/upload-raw-data) &#124; [UploadFile](http://electron.atom.io/docs/api/structures/upload-file) &#124; [UploadFileSystem](http://electron.atom.io/docs/api/structures/upload-file-system) &#124; [UploadBlob](http://electron.atom.io/docs/api/structures/upload-blob))[] - (optional)
 
 Same as `webContents.loadURL(url[, options])`.
 

--- a/_docs/api/clipboard.md
+++ b/_docs/api/clipboard.md
@@ -44,7 +44,7 @@ sort_title: "clipboard"
 
 > Perform copy and paste operations on the system clipboard.
 
-Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Rendere)
+Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)
 
 The following example shows how to write a string to the clipboard:
 

--- a/_docs/api/crash-reporter.md
+++ b/_docs/api/crash-reporter.md
@@ -44,7 +44,7 @@ sort_title: "crashreporter"
 
 > Submit crash reports to a remote server.
 
-Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Rendere)
+Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)
 
 The following is an example of automatically submitting a crash report to a
 remote server:

--- a/_docs/api/dialog.md
+++ b/_docs/api/dialog.md
@@ -119,7 +119,7 @@ shown.
   * `defaultPath` String (optional)
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
-  * `filters` structrs/file-filter) (optional
+  * `filters` structrs/file-filter (optional)
 * `callback` Function (optional)
   * `filename` String
 

--- a/_docs/api/native-image.md
+++ b/_docs/api/native-image.md
@@ -44,7 +44,7 @@ sort_title: "nativeimage"
 
 > Create tray, dock, and application icons using PNG or JPG files.
 
-Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Rendere)
+Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)
 
 In Electron, for the APIs that take images, you can pass either file paths or
 `NativeImage` instances. An empty image will be used when `null` is passed.
@@ -199,7 +199,7 @@ Creates a new `NativeImage` instance from `dataURL`.
 
 > Natively wrap images such as tray, dock, and application icons.
 
-Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Rendere)
+Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)
 
 ### Instance Methods
 

--- a/_docs/api/process.md
+++ b/_docs/api/process.md
@@ -44,7 +44,7 @@ sort_title: "process"
 
 > Extensions to process object.
 
-Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Rendere)
+Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)
 
 Electron's `process` object is extended from the
 [Node.js `process` object](https://nodejs.org/api/process.html).

--- a/_docs/api/screen.md
+++ b/_docs/api/screen.md
@@ -44,7 +44,7 @@ sort_title: "screen"
 
 > Retrieve information about screen size, displays, cursor position, etc.
 
-Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Rendere)
+Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)
 
 You cannot require or use this module until the `ready` event of the `app`
 module is emitted.

--- a/_docs/api/session.md
+++ b/_docs/api/session.md
@@ -400,14 +400,14 @@ Returns `Blob` - The blob data associated with the `identifier`.
     number of seconds since UNIX epoch.
 
 Allows resuming `cancelled` or `interrupted` downloads from previous `Session`.
-The API will generate a [DownloadItem](http://electron.atom.io/docs/api/download-item) that can be accessed with the [will-downloa)
+The API will generate a [DownloadItem](http://electron.atom.io/docs/api/download-item) that can be accessed with the [will-download](#event-will-download)
 event. The [DownloadItem](http://electron.atom.io/docs/api/download-item) will not have any `WebContents` associated with it and
 the initial state will be `interrupted`. The download will start only when the
 `resume` API is called on the [DownloadItem](http://electron.atom.io/docs/api/download-item).
 
 #### `ses.clearAuthCache(options[, callback])`
 
-* `options` ([RemovePassword](http://electron.atom.io/docs/api/structures/remove-password) &#124; [RemoveClientCertificat)
+* `options` ([RemovePassword](http://electron.atom.io/docs/api/structures/remove-password) &#124; [RemoveClientCertificate](http://electron.atom.io/docs/api/structures/remove-client-certificate))
 * `callback` Function (optional) - Called when operation is done
 
 Clears the session’s HTTP authentication cache.

--- a/_docs/api/shell.md
+++ b/_docs/api/shell.md
@@ -44,7 +44,7 @@ sort_title: "shell"
 
 > Manage files and URLs using their default applications.
 
-Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Rendere)
+Process: [Main](http://electron.atom.io/docs/tutorial/quick-start#main-process), [Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)
 
 The `shell` module provides functions related to desktop integration.
 

--- a/_docs/api/web-contents.md
+++ b/_docs/api/web-contents.md
@@ -536,7 +536,7 @@ Emitted when the devtools window instructs the webContents to reload
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](http://electron.atom.io/docs/api/structures/upload-raw-data) &#124; [UploadFil)
+  * `postData` ([UploadRawData](http://electron.atom.io/docs/api/structures/upload-raw-data) &#124; [UploadFile](http://electron.atom.io/docs/api/structures/upload-file) &#124; [UploadFileSystem](http://electron.atom.io/docs/api/structures/upload-file-system) &#124; [UploadBlob](http://electron.atom.io/docs/api/structures/upload-blob))[] - (optional)
 
 Loads the `url` in the window. The `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`. If the load should bypass http cache then

--- a/_docs/api/web-view-tag.md
+++ b/_docs/api/web-view-tag.md
@@ -345,7 +345,7 @@ webview.addEventListener('dom-ready', () => {
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](http://electron.atom.io/docs/api/structures/upload-raw-data) &#124; [UploadFil)
+  * `postData` ([UploadRawData](http://electron.atom.io/docs/api/structures/upload-raw-data) &#124; [UploadFile](http://electron.atom.io/docs/api/structures/upload-file) &#124; [UploadFileSystem](http://electron.atom.io/docs/api/structures/upload-file-system) &#124; [UploadBlob](http://electron.atom.io/docs/api/structures/upload-blob))[] - (optional)
 
 Loads the `url` in the webview, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.

--- a/lib/doc-links.js
+++ b/lib/doc-links.js
@@ -28,8 +28,64 @@ var path = require('path')
 // - [words]: /abc/abc.html
 // - [words]: _abc/abc/abc.html
 
+var getFileDir = function getFileDir (p) {
+  var array = p.split(path.sep)
+  return array[array.length - 2]
+}
 
-module.exports = function fixLinks (dir, version, callback) {
+var getLinks = function getLinks (content) {
+  var tradRegex = /\[(?:[^\]]|\[\])+\]\((?!http)(.+)\)/mg
+  var footRegex = /\[[^\]]+\]:[\r\n\s]+((?!http).+)/mg
+  var tradLinks = content.match(tradRegex) || []
+  var footLinks = content.match(footRegex) || []
+  var links = tradLinks.concat(footLinks)
+  return links
+}
+exports.getLinks = getLinks
+
+var fixLink = function fixLink(file, link) {
+  var baseUrl = 'electron.atom.io/docs/'
+  var tradLinkStyle = true
+  var parts
+  var bracket
+
+  if (link.match(/\]\(/)) {
+    parts = link.split('](')
+  } else {
+    parts = link.split(']:')
+    tradLinkStyle = false
+  }
+  var href = parts[1].trim()
+  if (tradLinkStyle) href = href.slice(0, href.length - 1)
+
+  if (tradLinkStyle) bracket = parts[0] + ']'
+  else bracket = parts[0] + ']: '
+
+  if (!href.match(/\.md/ig)) return link
+
+  var newLink = href.replace(/\.md/ig, '')
+  if (newLink.match('structures')) {
+    newLink = 'http://' + path.join(baseUrl, 'api', newLink).split(path.sep).join('/')
+    if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
+    else newMdLink = bracket + newLink
+    return newMdLink
+  } else if (newLink.indexOf('../') > -1) {
+    newLink = 'http://' + path.join(baseUrl, newLink.replace('../', '')).split(path.sep).join('/')
+    if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
+    else newMdLink = bracket + newLink
+    return newMdLink
+  } else if (newLink.indexOf('./') > -1 || newLink.indexOf('/') < 0) {
+    var fileDir = getFileDir(file)
+    newLink = 'http://' + path.join(baseUrl, fileDir, newLink).split(path.sep).join('/')
+    if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
+    else newMdLink = bracket + newLink
+    return newMdLink
+  }
+  return newLink
+}
+exports.fixLink = fixLink
+
+exports.fixLinks = function fixLinks (dir, version, callback) {
   var filesWithLinks = 0
   var filesToCheck = 0
   var filesProcessed = 0
@@ -47,12 +103,8 @@ module.exports = function fixLinks (dir, version, callback) {
   })
 
   function findLinks (file, i) {
-    var tradRegex = /\[(?:[^\]]|\[\])+\]\((?!http)(.+)\)/mg
-    var footRegex = /\[[^\]]+\]:[\r\n\s]+((?!http).+)/mg
     var content = fs.readFileSync(file).toString()
-    var tradLinks = content.match(tradRegex) || []
-    var footLinks = content.match(footRegex) || []
-    var links = tradLinks.concat(footLinks)
+    var links = getLinks(content)
 
     if (links.length > 0) {
       filesWithLinks++
@@ -62,54 +114,10 @@ module.exports = function fixLinks (dir, version, callback) {
   }
 
   function fixInternalLinks (file, content, links) {
-    var baseUrl = 'electron.atom.io/docs/'
-
-    var newLinks = links.map(function fixLinks (link, i) {
-      var tradLinkStyle = true
-      var parts
-      var bracket
-
-      if (link.match(/\]\(/)) {
-        parts = link.split('](')
-      } else {
-        parts = link.split(']:')
-        tradLinkStyle = false
-      }
-      var href = parts[1].trim()
-      if (tradLinkStyle) href = href.slice(0, href.length - 1)
-
-      if (tradLinkStyle) bracket = parts[0] + ']'
-      else bracket = parts[0] + ']: '
-
-      if (href.match(/\.md/ig)) {
-        var newLink = href.replace(/\.md/ig, '')
-        if (newLink.match('structures')) {
-          newLink = 'http://' + path.join(baseUrl, 'api', newLink).split(path.sep).join('/')
-          if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
-          else newMdLink = bracket + newLink
-          return newMdLink
-        } else if (newLink.indexOf('../') > -1) {
-          newLink = 'http://' + path.join(baseUrl, newLink.replace('../', '')).split(path.sep).join('/')
-          if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
-          else newMdLink = bracket + newLink
-          return newMdLink
-        } else if (newLink.indexOf('./') > -1 || newLink.indexOf('/') < 0) {
-          var fileDir = getFileDir(file)
-          newLink = 'http://' + path.join(baseUrl, fileDir, newLink).split(path.sep).join('/')
-          if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
-          else newMdLink = bracket + newLink
-          return newMdLink
-        }
-        return newLink
-      }
-      return link
+    var newLinks = links.map(function (link) {
+      return fixLink(file, link)
     })
     replaceLinksInContent(file, content, links, newLinks)
-  }
-
-  function getFileDir (p) {
-    var array = p.split(path.sep)
-    return array[array.length - 2]
   }
 
   function replaceLinksInContent (file, content, oldLinks, newLinks) {

--- a/lib/doc-links.js
+++ b/lib/doc-links.js
@@ -34,7 +34,7 @@ var getFileDir = function getFileDir (p) {
 }
 
 var getLinks = function getLinks (content) {
-  var tradRegex = /\[(?:[^\]]|\[\])+\]\((?!http)(.+)\)/mg
+  var tradRegex = /\[(?:[^\]]|\[\])+\]\((?!http)([^\)]+)\)/mg
   var footRegex = /\[[^\]]+\]:[\r\n\s]+((?!http).+)/mg
   var tradLinks = content.match(tradRegex) || []
   var footLinks = content.match(footRegex) || []

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -14,7 +14,7 @@ var rimraf = require('rimraf')
 var yaml = require('yamljs')
 var toTitleCase = require('titlecase')
 
-var formatInternalLinks = require('../lib/doc-links.js')
+var formatInternalLinks = require('../lib/doc-links.js').fixLinks
 var token = process.env.ATOM_ACCESS_TOKEN || 'da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4'
 var tarballFilename = 'electron.tar.gz'
 

--- a/spec/link-fixing.js
+++ b/spec/link-fixing.js
@@ -3,7 +3,10 @@
 var fs = require('fs')
 var test = require('tape')
 
-var fixInternalLinks = require('../lib/doc-links.js').fixLinks
+var docLinks = require('../lib/doc-links.js')
+var fixInternalLinks = docLinks.fixLinks
+var getLinks = docLinks.getLinks
+var fixLink = docLinks.fixLink
 
 var tradRegex = /\[.+\]\(.+\)/g
 var footRegex = /\[[^\]]+\]:\s(.+)/g
@@ -57,4 +60,13 @@ test('Parse empty directory', function (t) {
     t.equal(error.message, 'Found no relative links in files.', 'Got correct error message.')
     t.end()
   })
+})
+
+test('Fixes multiple links on one line', function(t) {
+  var content = 'Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)'
+  var links = getLinks(content)
+  t.equal(links.length, 2)
+  t.equal(fixLink('/file.md', links[0]), '[Main](http://electron.atom.io/docs/tutorial/quick-start#main-process)')
+  t.equal(fixLink('/file.md', links[1]), '[Renderer](http://electron.atom.io/docs/tutorial/quick-start#renderer-process)')
+  t.end()
 })

--- a/spec/link-fixing.js
+++ b/spec/link-fixing.js
@@ -3,7 +3,7 @@
 var fs = require('fs')
 var test = require('tape')
 
-var fixInternalLinks = require('../lib/doc-links.js')
+var fixInternalLinks = require('../lib/doc-links.js').fixLinks
 
 var tradRegex = /\[.+\]\(.+\)/g
 var footRegex = /\[[^\]]+\]:\s(.+)/g


### PR DESCRIPTION
Regex was using `.+` which would go all the way to the end of the last `)` found, now switched to use `[^)]+` instead so it stops at the first `)`.

This pull request also includes a rebuild of the docs to make sure only the broken links gets fixed.

Closes #567 