### PR TITLE
read latest version from data, not config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,6 @@ gems:
     - jekyll-seo-tag
     - jekyll-feed
     - jemoji
-latest_version: 1.4.12
 sass:
     style: compressed
 collections:

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class='subtron text-left'>
   <div class='container-narrow'>
-    <h1><span class="mr-3 mr-lg-4">Electron Documentation</span><span class="docs-version">{{ site.latest_version }}</span></h1>
+    <h1><span class="mr-3 mr-lg-4">Electron Documentation</span><span class="docs-version">{{ site.data.versions[0].version }}</span></h1>
 
     <h4 class="docs-breadcrumbs">
       <a href='{{ site.baseurl }}/docs/'>Docs</a>

--- a/_pages/docs.html
+++ b/_pages/docs.html
@@ -40,7 +40,7 @@ layout: default
 
 <div class='subtron'>
   <div class='container-narrow'>
-    <h1><span class="mr-3 mr-lg-4">Electron Documentation</span><span class="docs-version">{{ site.latest_version }}</span></h1>
+    <h1><span class="mr-3 mr-lg-4">Electron Documentation</span><span class="docs-version">{{ site.data.versions[0].version }}</span></h1>
     <p class="lead mb-3">
       See all of the <a href="{{ site.baseurl }}/docs/all/">docs on one page</a> or check out the <a href="{{ site.baseurl }}/docs/faq/">FAQ</a>.
     </p>

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -18,7 +18,7 @@ layout: default
   <div class="subtron py-4 text-center">
     <div class="container">
       <div id="electron-versions" class="electron-versions">
-        <span class="electron-versions-main">Electron: <strong>{{ site.latest_version }}</strong></span>
+        <span class="electron-versions-main">Electron: <strong>{{ site.data.versions[0].version }}</strong></span>
         <span>Node: <strong>{{ site.data.versions[0].node }}</strong></span>
         <span>Chromium: <strong>{{ site.data.versions[0].chrome }}</strong></span>
         <span>V8: <strong>{{ site.data.versions[0].v8 }}</strong></span>

--- a/_posts/2015-06-04-electron-doumentation.md
+++ b/_posts/2015-06-04-electron-doumentation.md
@@ -79,7 +79,7 @@ The file `latest.md` in our site root is empty except for this front matter whic
 ```yaml
 ---
 permalink: /docs/latest/
-redirect_to: /docs/{{ site.latest_version }}
+redirect_to: /docs/{{ site.data.versions[0].version }}
 ---
 ```
 


### PR DESCRIPTION
There were some leftover spots in the templates that were reading a `latest_version` value from the Jekyll config. Nowadays, the config file is just for configuration. All the ever-changing Electron-related data lives in the `_data` directory.