### PR TITLE
Improve readme and contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Jekyll uses the [Liquid templating language](https://wiki.github.com/shopify/liq
 This allows templates to be written in HTML or Markdown, and all templates have access to a `site`
 object containing all the content from the `_data` directory.
 
-## Running and Developing the Site Locally
+## Developing the Site Locally
 
 To build a Jekyll site you'll need a few things on your system (like Ruby) so double check the [Jekyll requirements](https://jekyllrb.com/docs/installation/#requirements).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,21 +6,21 @@ The following is a set of guidelines for contributing to electron.atom.io on Git
 
 ## Issues & Pull Requests
 
-* If you're not sure about adding something, open an issue to discuss it.
+* If you're not sure about adding something, [open an issue](https://github.com/electron/electron.atom.io/issues/new) to discuss it.
 * Feel free to open a Pull Request early so that a discussion can be had as changes are developed.
 * Include screenshots and animated gifs of your changes whenever possible.
-* End files with a newline.
 
+## Adding or Editing Site Content
 
-## Adding an app or project to the site
+### Apps
 
 See [github.com/electron/electron-apps#adding-your-app](https://github.com/electron/electron-apps#adding-your-app).
 
-## Adding a meetup to the site
+### Meetups
 
 If you want to add a meetup to the community site please open a pull request.
 
-Add the meetup to the list by editing [_data/meetups.yml](/_data/meetups.yml).
+Add the meetup to the **bottom** of the list by editing [_data/meetups.yml](/_data/meetups.yml).
 
 ```yml
 -
@@ -30,16 +30,82 @@ Add the meetup to the list by editing [_data/meetups.yml](/_data/meetups.yml).
   href: Link to meetup's site
 ```
 
-**Please add the meetup at the bottom of the list**.
-
-## Documentation
+### Documentation
 
 The documentation on this site is pulled directly from the `electron/electron` repository's `docs` directory. Contributions to the documentation should be made there: [electron/electron](https://github.com/electron/electron/tree/master/docs).
 
-## Blog Posts
+### Blog Posts
 
 A few guidelines to keep in mind when publishing a blog post:
 
 * Posts should normally be published on Tuesday mornings (Pacific time) for maximum social reach.
 * Make sure the date in the filename is today's date
 * Tweet about it once the post is live!
+
+## How the Site is Built
+
+### Styles
+
+The styles are based on [Primer](https://github.com/primer/primer-css), the CSS toolkit that powers GitHub's front-end design.  It's purposefully limited to common components to provide our developers with the most flexibility, and to keep GitHub uniquely GitHubby. It's built with SCSS and available via NPM, so it's easy to include all or part of it within your own project.
+
+### Frontend JavaScript
+
+There's not a lot of JavaScript on the site, so we currently just use
+[vendored](js/vendor) third-party scripts in script tags, most of which are
+browserify-friendly modules downloaded from the [wzrd.in](https://wzrd.in/) web service.
+
+### Metadata
+
+Much of the data for this website lives in the [_data](_data) directory. Jekyll loads data from YAML, JSON, and CSV files located in this directory and makes them available to all the templates.
+
+Metadata can also be added on a per-page basis using Jekyll's [YAML Frontmatter](https://jekyllrb.com/docs/frontmatter/) feature.
+
+### Templates
+
+Jekyll uses the [Liquid templating language](https://wiki.github.com/shopify/liquid/liquid-for-designers).
+This allows templates to be written in HTML or Markdown, and all templates have access to a `site`
+object containing all the content from the `_data` directory.
+
+## Running and Developing the Site Locally
+
+To build a Jekyll site you'll need a few things on your system (like Ruby) so double check the [Jekyll requirements](https://jekyllrb.com/docs/installation/#requirements).
+
+Follow these steps to copy this repository to your computer and build the site:
+
+```bash
+git clone https://github.com/electron/electron.atom.io.git
+cd electron.atom.io
+npm run bootstrap
+npm start
+```
+
+## Updating Docs, Apps, Releases, Userland, etc
+
+This site contains data gathered from various sources, and there's a build script for each:
+
+- `npm run build-releases` fetches release data from the GitHub API
+- `npm run build-docs` fetches version list from S3, fetches docs for the highest release version number, fixes their links, and adds YML frontmatter for Jekyll to use.
+- `npm run build-awesome` copies [awesome-electron](https://github.com/sindresorhus/awesome-electron/blob/npm-module/contributing.md#building-and-publishing-the-npm-package) data into the `_data` directory
+- `npm run build-userland` copies [electron-userland-reports](https://github.com/electron/electron-userland-reports) data into the `_data` directory
+- `npm run build-apps` copies [electron-apps](https://github.com/electron/electron-apps) data into the `_data` directory
+
+To run all of the build scripts serially:
+
+```sh
+npm run build
+npm test
+```
+
+To verify all the links in the site:
+
+```sh
+cd electron.atom.io
+npm start
+```
+
+Wait for the app to start, then in another shell:
+
+```sh
+cd electron.atom.io
+npm run link-checker
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,16 +44,6 @@ A few guidelines to keep in mind when publishing a blog post:
 
 ## How the Site is Built
 
-### Styles
-
-The styles are based on [Primer](https://github.com/primer/primer-css), the CSS toolkit that powers GitHub's front-end design.  It's purposefully limited to common components to provide our developers with the most flexibility, and to keep GitHub uniquely GitHubby. It's built with SCSS and available via NPM, so it's easy to include all or part of it within your own project.
-
-### Frontend JavaScript
-
-There's not a lot of JavaScript on the site, so we currently just use
-[vendored](js/vendor) third-party scripts in script tags, most of which are
-browserify-friendly modules downloaded from the [wzrd.in](https://wzrd.in/) web service.
-
 ### Metadata
 
 Much of the data for this website lives in the [_data](_data) directory. Jekyll loads data from YAML, JSON, and CSV files located in this directory and makes them available to all the templates.
@@ -65,6 +55,16 @@ Metadata can also be added on a per-page basis using Jekyll's [YAML Frontmatter]
 Jekyll uses the [Liquid templating language](https://wiki.github.com/shopify/liquid/liquid-for-designers).
 This allows templates to be written in HTML or Markdown, and all templates have access to a `site`
 object containing all the content from the `_data` directory.
+
+### Frontend JavaScript
+
+There's not a lot of JavaScript on the site, so we currently just use
+[vendored](js/vendor) third-party scripts in script tags, most of which are
+browserify-friendly modules downloaded from the [wzrd.in](https://wzrd.in/) web service.
+
+### Styles
+
+The styles are based on [Primer](https://github.com/primer/primer-css), the CSS toolkit that powers GitHub's front-end design.  It's purposefully limited to common components to provide our developers with the most flexibility, and to keep GitHub uniquely GitHubby. It's built with SCSS and available via NPM, so it's easy to include all or part of it within your own project.
 
 ## Developing the Site Locally
 

--- a/README.md
+++ b/README.md
@@ -1,58 +1,17 @@
 # electron.atom.io
 
-The [website](http://electron.atom.io) for [Electron](https://github.com/electron/electron): [electron.atom.io](http://electron.atom.io).
+This is the source code for the [Electron website](http://electron.atom.io).
 
-- **[Add a project to electron.atom.io/apps](CONTRIBUTING.md#adding-an-app-or-project-to-the-site)**
-- **[Add a meetup to electron.atom.io/community](CONTRIBUTING.md#adding-a-meetup-to-the-site)**
+It's a static [Jekyll](https://jekyllrb.com) site hosted on [GitHub Pages](https://pages.github.com).
 
-### Running the site
+## Contributing
 
-This is a [Jekyll](https://jekyllrb.com) site hosted on [GitHub Pages](https://pages.github.com). To build a Jekyll site you'll need a few things on your system so double check the [Jekyll requirements](https://jekyllrb.com/docs/installation/#requirements).
+- [Adding your app to electron.atom.io/apps](https://github.com/electron/electron-apps#adding-your-app)
+- [Adding a meetup to electron.atom.io/community](CONTRIBUTING.md#apps)
+- [Improving the Electron documentation](CONTRIBUTING.md#documentation)
 
-Follow these steps to copy this repository to your computer and build the site:
+For more info about how this site works and how to contribute, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-```bash
-git clone https://github.com/electron/electron.atom.io.git
-cd electron.atom.io
-npm run bootstrap
-npm start
-```
-
-### Updating Docs, Apps, Releases, Userland, etc
-
-This site contains data gathered from various sources, and there's a build script for each:
-
-- `npm run build-releases` fetches release data from the GitHub API
-- `npm run build-docs` fetches version list from S3, fetches docs for the highest release version number, fixes their links, and adds YML frontmatter for Jekyll to use.
-- `npm run build-awesome` copies [awesome-electron](https://github.com/sindresorhus/awesome-electron/blob/npm-module/contributing.md#building-and-publishing-the-npm-package) data into the `_data` directory
-- `npm run build-userland` copies [electron-userland-reports](https://github.com/electron/electron-userland-reports) data into the `_data` directory
-- `npm run build-apps` copies [electron-apps](https://github.com/electron/electron-apps) data into the `_data` directory
-
-To run all of the build scripts serially:
-
-```sh
-npm run build
-npm test
-```
-
-To verify all the links in the site:
-
-```sh
-cd electron.atom.io
-npm start
-```
-
-Wait for the app to start, then in another shell:
-
-```sh
-cd electron.atom.io
-npm run link-checker
-```
-
-### Contributing
-
-Thanks for contributing to the site! Checkout the [contributing documentation](CONTRIBUTING.md) for guidelines on pull requests.
-
-### License
+## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # electron.atom.io
 
-This is the source code for the [Electron website](http://electron.atom.io).
-
-It's a static [Jekyll](https://jekyllrb.com) site hosted on [GitHub Pages](https://pages.github.com).
+This is the source code for the [Electron website](http://electron.atom.io). It's a static [Jekyll](https://jekyllrb.com) site hosted on [GitHub Pages](https://pages.github.com).
 
 ## Contributing
 
 - [Adding your app to electron.atom.io/apps](https://github.com/electron/electron-apps#adding-your-app)
-- [Adding a meetup to electron.atom.io/community](CONTRIBUTING.md#apps)
+- [Adding a meetup to electron.atom.io/community](CONTRIBUTING.md#meetups)
 - [Improving the Electron documentation](CONTRIBUTING.md#documentation)
 
 For more info about how this site works and how to contribute, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
@felixrieseberg recently asked what "frameworks" we are using on the site.

This PR is an attempt to answer that question. Specifically: https://github.com/electron/electron.atom.io/blob/5ed85c4fb606aeae73d03a194e3d6b336776905d/CONTRIBUTING.md#how-the-site-is-built

I also moved most of the contributing info to `CONTRIBUTING.md` and pared down the README to include a few links to address the most common contribution cases:

1. adding apps
1. adding meetups
1. updating docs