### PR TITLE
fix userland repo links

### DIFF
--- a/_includes/userland_report.html
+++ b/_includes/userland_report.html
@@ -34,7 +34,7 @@
         <ul class="filterable-list">
           {% for repo in report.collection %}
             <li data-rank="{{forloop.index}}">
-              <a class="item-name" href="{{repo.htmlUrl}}">{{repo.fullName}}</a>
+              <a class="item-name" href="https://github.com/{{repo.fullName}}">{{repo.fullName}}</a>
               {% if repo.description %}
                 <span class="item-description">{{repo.description}}</span>
               {% endif %}


### PR DESCRIPTION
There was a point at which [repos-using-electron](https://github.com/electron/repos-using-electron) was omitting [all those `foo_bar_baz_url` properties](https://api.github.com/repos/electron/electron) that are returned by the GitHub API, but now those properties (though largely redundant) are retained, because having them doesn't really hurt anything.

So... some repos are missing `htmlUrl`. This PR works around that by constructing the repo URL with `fullName`, a property which every repo is [guaranteed to have](https://github.com/electron/repos-using-electron/blob/3551ef4210f052d59dd65f0885e079fe564a9edc/test/index.js#L28-L31).

Also opened https://github.com/electron/repos-using-electron/issues/13 as a reminder to eventually fix the data at the source.

Thanks to @pfrazee for reporting.