### PR TITLE
fix link tests to account for electron docs changes

### DIFF
--- a/test.js
+++ b/test.js
@@ -38,13 +38,13 @@ describe('electron.atom.io', () => {
   describe('docs', () => {
     it('rewrites relative links', () => {
       const doc = loadDoc('api/browser-window.md')
-      expect(doc).to.include('[Main]({{site.baseurl}}/docs/tutorial/quick-start#main-process)')
+      expect(doc).to.include('[Main]({{site.baseurl}}/docs/glossary#main-process)')
     })
 
     it('properly handles multiple links on a single line', () => {
       const doc = loadDoc('api/clipboard.md')
-      expect(doc).to.include('[Main]({{site.baseurl}}/docs/tutorial/quick-start#main-process)')
-      expect(doc).to.include('[Renderer]({{site.baseurl}}/docs/tutorial/quick-start#renderer-process)')
+      expect(doc).to.include('[Main]({{site.baseurl}}/docs/glossary#main-process)')
+      expect(doc).to.include('[Renderer]({{site.baseurl}}/docs/glossary#renderer-process)')
     })
 
     it('leaves absolute links intact', () => {


### PR DESCRIPTION
https://github.com/electron/electron/pull/7878/files rewrites the URL of the `Main Process` and `Renderer Process` links in each API doc.  Once that lands in a release, a few tests will start failing here.

This PR exists in anticipation of that future...