### PR TITLE
link to contact page from header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,7 @@
       <a class="site-header-nav-item {% if first_segment == 'apps' %}active{% endif %}" href="{{ site.baseurl }}/apps/">Apps</a>
       <a class="site-header-nav-item {% if first_segment == 'userland' %}active{% endif %}" href="{{ site.baseurl }}/userland/">Userland</a>
       <a class="site-header-nav-item {% if first_segment == 'releases' %}active{% endif %}" href="{{ site.baseurl }}/releases/">Releases</a>
-      <a class="site-header-nav-item" href="https://discuss.atom.io/c/electron">Discuss</a>
+      <a class="site-header-nav-item {% if first_segment == 'contact' %}active{% endif %}" href="{{ site.baseurl }}/contact/">Contact</a>
       <a class="site-header-nav-item" href="https://github.com/electron/electron" title="Github Repository"><span class="mega-octicon octicon-mark-github vertical-middle"></span></a>
     </nav>
   </div>


### PR DESCRIPTION
This PR replaces the link to https://discuss.atom.io/c/electron with a link to http://electron.atom.io/contact/ which lists our GitHub, Twitter, Slack, Discourse, and email address.

Eventually it would be nice to have a short blurb outlining the purpose of each of those accounts,  but this is at least a start to help people more easily find the available channels for communicating with us and the community.