### PR TITLE
Encode pipes

### DIFF
--- a/_docs/api/browser-window.md
+++ b/_docs/api/browser-window.md
@@ -219,7 +219,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     *   `skipTaskbar` Boolean (optional) - Whether to show the window in taskbar. Default is `false`.
     *   `kiosk` Boolean (optional) - The kiosk mode. Default is `false`.
     *   `title` String (optional) - Default window title. Default is `"Electron"`.
-    *   `icon` ([NativeImage]({{site.baseurl}}/docs/api/native-image) | String) (optional) - The window icon. On Windows it is recommended to use `ICO` icons to get best visual effects, you can also leave it undefined so the executable's icon will be used.
+    *   `icon` ([NativeImage]({{site.baseurl}}/docs/api/native-image) &#124; String) (optional) - The window icon. On Windows it is recommended to use `ICO` icons to get best visual effects, you can also leave it undefined so the executable's icon will be used.
     *   `show` Boolean (optional) - Whether window should be shown when created. Default is `true`.
     *   `frame` Boolean (optional) - Specify `false` to create a [Frameless Window]({{site.baseurl}}/docs/api/frameless-window). Default is `true`.
     *   `parent` BrowserWindow (optional) - Specify parent window. Default is `null`.
@@ -908,7 +908,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
     *   `httpReferrer` String (optional) - A HTTP Referrer url.
     *   `userAgent` String (optional) - A user agent originating the request.
     *   `extraHeaders` String (optional) - Extra headers separated by "\n"
-    *   `postData` ([UploadRawData]({{site.baseurl}}/docs/api/structures/upload-raw-data) | [UploadFile]({{site.baseurl}}/docs/api/structures/upload-file) | [UploadFileSystem]({{site.baseurl}}/docs/api/structures/upload-file-system) | [UploadBlob]({{site.baseurl}}/docs/api/structures/upload-blob))[] - (optional)
+    *   `postData` ([UploadRawData]({{site.baseurl}}/docs/api/structures/upload-raw-data) &#124; [UploadFile]({{site.baseurl}}/docs/api/structures/upload-file) &#124; [UploadFileSystem]({{site.baseurl}}/docs/api/structures/upload-file-system) &#124; [UploadBlob]({{site.baseurl}}/docs/api/structures/upload-blob))[] - (optional)
 
 Same as `webContents.loadURL(url[, options])`.
 

--- a/_docs/api/client-request.md
+++ b/_docs/api/client-request.md
@@ -97,7 +97,7 @@ Process: [Main]({{site.baseurl}}/docs/tutorial/quick-start#main-process)
 
 ### `new ClientRequest(options)`
 
-*   `options` (Object | String) - If `options` is a String, it is interpreted as the request URL. If it is an object, it is expected to fully specify an HTTP request via the following properties:
+*   `options` (Object &#124; String) - If `options` is a String, it is interpreted as the request URL. If it is an object, it is expected to fully specify an HTTP request via the following properties:
     *   `method` String (optional) - The HTTP request method. Defaults to the GET method.
     *   `url` String (optional) - The request URL. Must be provided in the absolute form with the protocol scheme specified as http or https.
     *   `session` Object (optional) - The [`Session`]({{site.baseurl}}/docs/api/session) instance with which the request is associated.
@@ -220,7 +220,7 @@ Removes a previously set extra header name. This method can be called only befor
 
 #### `request.write(chunk[, encoding][, callback])`
 
-*   `chunk` (String | Buffer) - A chunk of the request body's data. If it is a string, it is converted into a Buffer using the specified encoding.
+*   `chunk` (String &#124; Buffer) - A chunk of the request body's data. If it is a string, it is converted into a Buffer using the specified encoding.
 *   `encoding` String (optional) - Used to convert string chunks into Buffer objects. Defaults to 'utf-8'.
 *   `callback` Function (optional) - Called after the write operation ends.
 
@@ -230,7 +230,7 @@ Adds a chunk of data to the request body. The first write operation may cause th
 
 #### `request.end([chunk][, encoding][, callback])`
 
-*   `chunk` (String | Buffer) (optional)
+*   `chunk` (String &#124; Buffer) (optional)
 *   `encoding` String (optional)
 *   `callback` Function (optional)
 

--- a/_docs/api/menu-item.md
+++ b/_docs/api/menu-item.md
@@ -107,11 +107,11 @@ See [`Menu`]({{site.baseurl}}/docs/api/menu) for examples.
     *   `label` String - (optional)
     *   `sublabel` String - (optional)
     *   `accelerator` [Accelerator]({{site.baseurl}}/docs/api/accelerator) - (optional)
-    *   `icon` ([NativeImage]({{site.baseurl}}/docs/api/native-image) | String) - (optional)
+    *   `icon` ([NativeImage]({{site.baseurl}}/docs/api/native-image) &#124; String) - (optional)
     *   `enabled` Boolean - (optional) If false, the menu item will be greyed out and unclickable.
     *   `visible` Boolean - (optional) If false, the menu item will be entirely hidden.
     *   `checked` Boolean - (optional) Should only be specified for `checkbox` or `radio` type menu items.
-    *   `submenu` (MenuItemConstructorOptions[] | Menu) - (optional) Should be specified for `submenu` type menu items. If `submenu` is specified, the `type: 'submenu'` can be omitted. If the value is not a `Menu` then it will be automatically converted to one using `Menu.buildFromTemplate`.
+    *   `submenu` (MenuItemConstructorOptions[] &#124; Menu) - (optional) Should be specified for `submenu` type menu items. If `submenu` is specified, the `type: 'submenu'` can be omitted. If the value is not a `Menu` then it will be automatically converted to one using `Menu.buildFromTemplate`.
     *   `id` String - (optional) Unique within a single menu. If defined then it can be used as a reference to this item by the position attribute.
     *   `position` String - (optional) This field allows fine-grained definition of the specific location within a given menu.
 

--- a/_docs/api/net.md
+++ b/_docs/api/net.md
@@ -135,7 +135,7 @@ The `net` module has the following methods:
 
 ### `net.request(options)`
 
-*   `options` (Object | String) - The `ClientRequest` constructor options.
+*   `options` (Object &#124; String) - The `ClientRequest` constructor options.
 
 Returns [`ClientRequest`]({{site.baseurl}}/docs/api/client-request)
 

--- a/_docs/api/session.md
+++ b/_docs/api/session.md
@@ -406,7 +406,7 @@ Allows resuming `cancelled` or `interrupted` downloads from previous `Session`. 
 
 #### `ses.clearAuthCache(options[, callback])`
 
-*   `options` ([RemovePassword]({{site.baseurl}}/docs/api/structures/remove-password) | [RemoveClientCertificate]({{site.baseurl}}/docs/api/structures/remove-client-certificate))
+*   `options` ([RemovePassword]({{site.baseurl}}/docs/api/structures/remove-password) &#124; [RemoveClientCertificate]({{site.baseurl}}/docs/api/structures/remove-client-certificate))
 *   `callback` Function (optional) - Called when operation is done
 
 Clears the session’s HTTP authentication cache.

--- a/_docs/api/tray.md
+++ b/_docs/api/tray.md
@@ -145,7 +145,7 @@ If you want to keep exact same behaviors on all platforms, you should not rely o
 
 ### `new Tray(image)`
 
-*   `image` ([NativeImage]({{site.baseurl}}/docs/api/native-image) | String)
+*   `image` ([NativeImage]({{site.baseurl}}/docs/api/native-image) &#124; String)
 
 Creates a new tray icon associated with the `image`.
 

--- a/_docs/api/web-contents.md
+++ b/_docs/api/web-contents.md
@@ -537,7 +537,7 @@ Emitted when the devtools window instructs the webContents to reload
     *   `httpReferrer` String (optional) - A HTTP Referrer url.
     *   `userAgent` String (optional) - A user agent originating the request.
     *   `extraHeaders` String (optional) - Extra headers separated by "\n"
-    *   `postData` ([UploadRawData]({{site.baseurl}}/docs/api/structures/upload-raw-data) | [UploadFile]({{site.baseurl}}/docs/api/structures/upload-file) | [UploadFileSystem]({{site.baseurl}}/docs/api/structures/upload-file-system) | [UploadBlob]({{site.baseurl}}/docs/api/structures/upload-blob))[] - (optional)
+    *   `postData` ([UploadRawData]({{site.baseurl}}/docs/api/structures/upload-raw-data) &#124; [UploadFile]({{site.baseurl}}/docs/api/structures/upload-file) &#124; [UploadFileSystem]({{site.baseurl}}/docs/api/structures/upload-file-system) &#124; [UploadBlob]({{site.baseurl}}/docs/api/structures/upload-blob))[] - (optional)
 
 Loads the `url` in the window. The `url` must contain the protocol prefix, e.g. the `http://` or `file://`. If the load should bypass http cache then use the `pragma` header to achieve it.
 

--- a/_docs/api/web-view-tag.md
+++ b/_docs/api/web-view-tag.md
@@ -332,7 +332,7 @@ webview.addEventListener('dom-ready', () => {
     *   `httpReferrer` String (optional) - A HTTP Referrer url.
     *   `userAgent` String (optional) - A user agent originating the request.
     *   `extraHeaders` String (optional) - Extra headers separated by "\n"
-    *   `postData` ([UploadRawData]({{site.baseurl}}/docs/api/structures/upload-raw-data) | [UploadFile]({{site.baseurl}}/docs/api/structures/upload-file) | [UploadFileSystem]({{site.baseurl}}/docs/api/structures/upload-file-system) | [UploadBlob]({{site.baseurl}}/docs/api/structures/upload-blob))[] - (optional)
+    *   `postData` ([UploadRawData]({{site.baseurl}}/docs/api/structures/upload-raw-data) &#124; [UploadFile]({{site.baseurl}}/docs/api/structures/upload-file) &#124; [UploadFileSystem]({{site.baseurl}}/docs/api/structures/upload-file-system) &#124; [UploadBlob]({{site.baseurl}}/docs/api/structures/upload-blob))[] - (optional)
 
 Loads the `url` in the webview, the `url` must contain the protocol prefix, e.g. the `http://` or `file://`.
 

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -43,6 +43,16 @@ module.exports = class Doc {
       this.frontmatter
     )
 
+    // Work around kramdown's misinterpretation of pipe as a table header
+    // https://github.com/electron/electron.atom.io/issues/556
+    this.output = this.output
+      .split('\n')
+      .map(line => {
+        const match = line.match(/^\s*\*\s+`/) && line.match(/ \| /)
+        return match ? line.replace(/ \| /g, ' &#124; ') : line
+      })
+      .join('\n')
+
     this.save()
   }
 

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -48,8 +48,7 @@ module.exports = class Doc {
     this.output = this.output
       .split('\n')
       .map(line => {
-        const match = line.match(/^\s*\*\s+`/) && line.match(/ \| /)
-        return match ? line.replace(/ \| /g, ' &#124; ') : line
+        return line.match(/^\s*\*\s+`/) ? line.replace(/ \| /g, ' &#124; ') : line
       })
       .join('\n')
 

--- a/test.js
+++ b/test.js
@@ -59,6 +59,11 @@ describe('electron.atom.io', () => {
       expect(doc).to.include('```javascript\n')
     })
 
+    it('HTML-encodes pipe characters to avoid confusing the jekyll kramdown parser', () => {
+      const doc = loadDoc('api/net.md')
+      expect(doc).to.include('(Object &#124; String)')
+    })
+
     describe('frontmatter', () => {
       const frontmatter = matter(loadDoc('api/app.md')).data
       it('has a semver version', () => {


### PR DESCRIPTION
Fixes #556 (again). This regressed because it [didn't have a test](https://github.com/electron/electron.atom.io/commit/6c4d991485a82c7b5ba09d4869ff7a0b9f4e6054), and fell through the cracks when #630 landed.

👁 @kevinsawicki 
