### PR TITLE
Removing London from meetups list

### DIFF
--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -34,11 +34,6 @@
   country: Turkey
   href: http://www.meetup.com/Electron-JS-Istanbul
 -
-  name: Electron Open Source Desktop Framework
-  location: London
-  country: England
-  href: http://www.meetup.com/Electron-Open-Source-Desktop-Framework/
--
   name: Electron JS Utah
   location: American Fork, UT
   country: USA


### PR DESCRIPTION
The London Meetups group seems to have disappeared. Probably ought to be removed from the website pending confirmation it exists.