### PR TITLE
Add focus styles to app list

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -125,14 +125,16 @@ $app-list-icon-size: 48px;
 .listed-app > a {
   display: flex;
   padding: 10px;
-  &:hover {
-    text-decoration: none;
-  }
+  border: 1px solid transparent;
 }
 
-.listed-app > a:hover {
+.listed-app > a:hover,
+.listed-app > a:focus {
   text-decoration: none;
+  text-decoration: none;
+  border-color: $main-border-color;
   background-color: $main-bg-color-shade;
+  outline: none;
 }
 
 .listed-app-logo-wrapper {

--- a/_sass/_userland.scss
+++ b/_sass/_userland.scss
@@ -99,6 +99,9 @@ ul.report-list {
   border: 1px solid #CCC;
   border-radius: 2px;
   margin: 10px 0;
+  &[type="search"] {
+    box-sizing: border-box;
+  }
 }
 
 /* Author List (for npm and GitHub users in /userland) */


### PR DESCRIPTION
This is a small follow up to #654.

After typing a search query, some people might just use `tab` to move down the list and then hit `enter`. This PR makes hover and focus styles the same. Border got added to make it a bit stronger.

![music](https://cloud.githubusercontent.com/assets/378023/22089377/129e65d6-de2e-11e6-9731-a5e712b9ebf3.gif)

👀  [Preview](http://simurai.com/electron.atom.io/apps/)