### PR TITLE
Use EOL anchor when replacing links

### DIFF
--- a/script/releases
+++ b/script/releases
@@ -27,8 +27,8 @@ request(options, function (error, response, body) {
 
       // turn PR references like #123 into hyperlinks
       release.body = release.body.replace(
-        / #(\d+)\r\n/gm,
-        ' <a href="https://github.com/electron/electron/pull/$1">#$1</a>\r\n'
+        / #(\d+)$/gm,
+        ' <a href="https://github.com/electron/electron/pull/$1">#$1</a>'
       )
     })
     fs.writeFileSync('_data/releases.json', JSON.stringify(body, null, 2))


### PR DESCRIPTION
Looks like http://electron.atom.io/ is still showing 1.4.14 even though 1.4.15 is out.

I ran `./script/release` locally and the specs were failing on 1.4.15 because of the hyperlink spec, looks like some releases use `\r\n` and others `\n`.

This pull request just use the `$` anchor so both are handled.