### PR TITLE
Release Notifications, Take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 npm-debug.log
 .jekyll-metadata
 images/crushed
+.env

--- a/package.json
+++ b/package.json
@@ -11,19 +11,20 @@
     "start": "script/server",
     "bootstrap": "script/bootstrap",
     "link-checker": "grunt linkChecker",
-    "test": "mocha && standard",
+    "test": "mocha --reporter min && standard",
     "build": "npm-run-all build-*",
     "build-releases": "script/releases",
     "build-docs": "script/docs",
     "build-awesome": "script/awesome",
     "build-userland": "script/userland",
     "build-apps": "script/apps",
-    "release": "script/release"
+    "release": "script/release |& script/notify"
   },
   "devDependencies": {
     "awesome-electron": "^2.5.0",
     "chai": "^3.5.0",
     "cheerio": "^0.22.0",
+    "dotenv": "^4.0.0",
     "electron-apps": "github:electron/electron-apps",
     "electron-docs": "^3.0.0",
     "electron-userland-reports": "1.6.0",
@@ -38,6 +39,7 @@
     "npm-run-all": "^3.1.2",
     "require-dir": "^0.3.1",
     "semver": "^5.3.0",
+    "slack-notify": "^0.1.6",
     "standard": "^8.6.0",
     "titlecase": "^1.0.2",
     "to-markdown": "github:zeke/to-markdown#support-markdown-it-gfm"

--- a/script/notify
+++ b/script/notify
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+// Load SLACK_WEBHOOK from .env (for local testing)
+require('dotenv').load()
+
+const slack = require('slack-notify')(process.env.SLACK_WEBHOOK)
+var input = ''
+
+// Collect STDOUT and STDERR from release script
+process.stdin
+  .setEncoding('utf8')
+  .on('readable', () => { input += String(process.stdin.read() || '') })
+  .on('end', send)
+
+function send () {
+  if (!input.match('npm ERR') && !input.match('Test failed')) {
+    return process.exit()
+  }
+
+  const opts = {
+    icon_url: 'https://avatars0.githubusercontent.com/u/18403005?v=3',
+    username: 'electron.atom.io',
+    text: input
+  }
+
+  slack.send(opts, (err) => {
+    if (err) throw err
+  })
+}


### PR DESCRIPTION
This PR replaces https://github.com/electron/electron.atom.io/pull/670, which I wasn't really very happy with. It was nice to experiment with `shelljs`, and work towards a build script that would work on Windows, but the code ended up being harder to read/write/understand because of the abstraction of JavaScript doing shell scripting... 🤔 

The new approach in this PR is simple:

- The [existing release script](https://github.com/electron/electron.atom.io/blob/60aedf6237a5b91b1f8e793155c295c7c9237670/script/release) remains untouched; it's a simple shell script.
- The `npm run release` command pipes STDOUT and STDERR to a new `notify` script (as well as the screen)
- The `notify` script collects its STDIN, then sends a Slack notification to the new `#website` channel if the input contains substrings that indicate failure.
- `mocha` is configured to use the `min` reporter, for more concise and actionable content in the notification.

Here's what it looks like in Slack:

<img width="580" alt="screen shot 2017-02-09 at 11 44 59 am" src="https://cloud.githubusercontent.com/assets/2289/22800745/36de5658-eebf-11e6-9b68-3cfff7c88fb4.png">

The Slack webhook configuration is at https://electronhq.slack.com/apps/A0F7XDUAZ-incoming-webhooks

This is ready for review.

cc @electron/maintainers 

