### PR TITLE
Get `electron-apps` from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^3.5.0",
     "cheerio": "^0.22.0",
     "dotenv": "^4.0.0",
-    "electron-apps": "github:electron/electron-apps",
+    "electron-apps": "^1.3.0",
     "electron-docs": "^3.0.0",
     "electron-userland-reports": "1.6.0",
     "got": "^6.6.3",


### PR DESCRIPTION
There's now a bot that periodically [adds metadata](https://github.com/electron/electron-apps/pull/89) to the `electron-apps` repo and publishes it to npm. The bot runs a build script that generates artifacts that are gitignored, like resized icons. This PR updates the website to use that new package instead of the master branch of the `electron-apps` repo.