### PR TITLE
include up to 100 releases, not just 30

### DIFF
--- a/script/releases
+++ b/script/releases
@@ -5,7 +5,7 @@ const request = require('request')
 const semver = require('semver')
 const token = process.env.ATOM_ACCESS_TOKEN || 'da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4'
 const options = {
-  url: 'https://api.github.com/repos/electron/electron/releases',
+  url: 'https://api.github.com/repos/electron/electron/releases?per_page=100',
   json: true,
   headers: {
     'user-agent': 'Electron',


### PR DESCRIPTION
This updates the build script to collect metadata for more than 30 releases, and as many as 100.