### PR TITLE
use highest stable version when building docs

### DIFF
--- a/lib/doc.js
+++ b/lib/doc.js
@@ -7,7 +7,8 @@ const marky = require('marky-markdown-lite')
 const matter = require('gray-matter')
 const dedent = require('dedent')
 const toMarkdown = require('to-markdown')
-const versions = require(path.join(__dirname, '../_data/versions.json')).map(v => v.version)
+const versions = require('../_data/versions.json').map(v => v.version)
+const highestStableVersion = require('../_data/releases.json')[0].version
 const hrefType = require('href-type')
 
 module.exports = class Doc {
@@ -27,7 +28,7 @@ module.exports = class Doc {
 
     // Derive YML frontmatter for Jekyll
     this.frontmatter = {
-      version: `v${versions[0]}`,
+      version: `v${highestStableVersion}`,
       permalink: this.permalink,
       category: this.category,
       redirect_from: this.redirects,


### PR DESCRIPTION
I missed an important spot when implementing https://github.com/electron/electron.atom.io/pull/673 -- this is a fix for that.