### PR TITLE
re #705: Prevent app icon from scaling down when screen width is small.

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -143,6 +143,11 @@ $app-list-icon-size: 48px;
   height: $app-list-icon-size;
 }
 
+.listed-app-logo {
+    max-width: 48px;
+    height: 48px;
+}
+
 .listed-app-name {
   padding: 0 10px;
   font-weight: 500;


### PR DESCRIPTION
In #705 is mentioned a small bug related to the app icon size on hover, on narrow screens.
https://github.com/electron/electron.atom.io/issues/705#issuecomment-285457761

This fixes it by not allowing the app icon to scale down anymore.
