### PR TITLE
sort versions data from S3 (v8, chromium, node)

### DIFF
--- a/_data/versions.json
+++ b/_data/versions.json
@@ -253,29 +253,6 @@
     ]
   },
   {
-    "version": "1.3.13",
-    "date": "2016-12-06",
-    "node": "6.5.0",
-    "v8": "5.2.361.43",
-    "uv": "1.9.1",
-    "zlib": "1.2.8",
-    "openssl": "1.0.2h",
-    "modules": "49",
-    "chrome": "52.0.2743.82",
-    "files": [
-      "darwin-x64",
-      "darwin-x64-symbols",
-      "linux-ia32",
-      "linux-ia32-symbols",
-      "linux-x64",
-      "linux-x64-symbols",
-      "win32-ia32",
-      "win32-ia32-symbols",
-      "win32-x64",
-      "win32-x64-symbols"
-    ]
-  },
-  {
     "version": "1.4.10",
     "date": "2016-11-28",
     "node": "6.5.0",
@@ -331,52 +308,6 @@
     "openssl": "1.0.2h",
     "modules": "50",
     "chrome": "53.0.2785.143",
-    "files": [
-      "darwin-x64",
-      "darwin-x64-symbols",
-      "linux-ia32",
-      "linux-ia32-symbols",
-      "linux-x64",
-      "linux-x64-symbols",
-      "win32-ia32",
-      "win32-ia32-symbols",
-      "win32-x64",
-      "win32-x64-symbols"
-    ]
-  },
-  {
-    "version": "1.3.10",
-    "date": "2016-11-22",
-    "node": "6.5.0",
-    "v8": "5.2.361.43",
-    "uv": "1.9.1",
-    "zlib": "1.2.8",
-    "openssl": "1.0.2h",
-    "modules": "49",
-    "chrome": "52.0.2743.82",
-    "files": [
-      "darwin-x64",
-      "darwin-x64-symbols",
-      "linux-ia32",
-      "linux-ia32-symbols",
-      "linux-x64",
-      "linux-x64-symbols",
-      "win32-ia32",
-      "win32-ia32-symbols",
-      "win32-x64",
-      "win32-x64-symbols"
-    ]
-  },
-  {
-    "version": "1.3.9",
-    "date": "2016-11-16",
-    "node": "6.5.0",
-    "v8": "5.2.361.43",
-    "uv": "1.9.1",
-    "zlib": "1.2.8",
-    "openssl": "1.0.2h",
-    "modules": "49",
-    "chrome": "52.0.2743.82",
     "files": [
       "darwin-x64",
       "darwin-x64-symbols",
@@ -529,29 +460,6 @@
     ]
   },
   {
-    "version": "1.3.7",
-    "date": "2016-09-27",
-    "node": "6.5.0",
-    "v8": "5.2.361.43",
-    "uv": "1.9.1",
-    "zlib": "1.2.8",
-    "openssl": "1.0.2h",
-    "modules": "49",
-    "chrome": "52.0.2743.82",
-    "files": [
-      "darwin-x64",
-      "darwin-x64-symbols",
-      "linux-ia32",
-      "linux-ia32-symbols",
-      "linux-x64",
-      "linux-x64-symbols",
-      "win32-ia32",
-      "win32-ia32-symbols",
-      "win32-x64",
-      "win32-x64-symbols"
-    ]
-  },
-  {
     "version": "1.4.1",
     "date": "2016-09-22",
     "node": "6.5.0",
@@ -584,6 +492,121 @@
     "openssl": "1.0.2h",
     "modules": "50",
     "chrome": "53.0.2785.113",
+    "files": [
+      "darwin-x64",
+      "darwin-x64-symbols",
+      "linux-ia32",
+      "linux-ia32-symbols",
+      "linux-x64",
+      "linux-x64-symbols",
+      "win32-ia32",
+      "win32-ia32-symbols",
+      "win32-x64",
+      "win32-x64-symbols"
+    ]
+  },
+  {
+    "version": "1.3.14",
+    "date": "2017-03-14",
+    "node": "6.5.0",
+    "v8": "5.2.361.43",
+    "uv": "1.9.1",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2h",
+    "modules": "49",
+    "chrome": "52.0.2743.82",
+    "files": [
+      "darwin-x64",
+      "darwin-x64-symbols",
+      "linux-ia32",
+      "linux-ia32-symbols",
+      "linux-x64",
+      "linux-x64-symbols",
+      "win32-ia32",
+      "win32-ia32-symbols",
+      "win32-x64",
+      "win32-x64-symbols"
+    ]
+  },
+  {
+    "version": "1.3.13",
+    "date": "2016-12-06",
+    "node": "6.5.0",
+    "v8": "5.2.361.43",
+    "uv": "1.9.1",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2h",
+    "modules": "49",
+    "chrome": "52.0.2743.82",
+    "files": [
+      "darwin-x64",
+      "darwin-x64-symbols",
+      "linux-ia32",
+      "linux-ia32-symbols",
+      "linux-x64",
+      "linux-x64-symbols",
+      "win32-ia32",
+      "win32-ia32-symbols",
+      "win32-x64",
+      "win32-x64-symbols"
+    ]
+  },
+  {
+    "version": "1.3.10",
+    "date": "2016-11-22",
+    "node": "6.5.0",
+    "v8": "5.2.361.43",
+    "uv": "1.9.1",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2h",
+    "modules": "49",
+    "chrome": "52.0.2743.82",
+    "files": [
+      "darwin-x64",
+      "darwin-x64-symbols",
+      "linux-ia32",
+      "linux-ia32-symbols",
+      "linux-x64",
+      "linux-x64-symbols",
+      "win32-ia32",
+      "win32-ia32-symbols",
+      "win32-x64",
+      "win32-x64-symbols"
+    ]
+  },
+  {
+    "version": "1.3.9",
+    "date": "2016-11-16",
+    "node": "6.5.0",
+    "v8": "5.2.361.43",
+    "uv": "1.9.1",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2h",
+    "modules": "49",
+    "chrome": "52.0.2743.82",
+    "files": [
+      "darwin-x64",
+      "darwin-x64-symbols",
+      "linux-ia32",
+      "linux-ia32-symbols",
+      "linux-x64",
+      "linux-x64-symbols",
+      "win32-ia32",
+      "win32-ia32-symbols",
+      "win32-x64",
+      "win32-x64-symbols"
+    ]
+  },
+  {
+    "version": "1.3.7",
+    "date": "2016-09-27",
+    "node": "6.5.0",
+    "v8": "5.2.361.43",
+    "uv": "1.9.1",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2h",
+    "modules": "49",
+    "chrome": "52.0.2743.82",
     "files": [
       "darwin-x64",
       "darwin-x64-symbols",
@@ -1265,29 +1288,6 @@
     ]
   },
   {
-    "version": "0.36.12",
-    "date": "2016-03-27",
-    "node": "5.1.1",
-    "v8": "4.7.80.27",
-    "uv": "1.7.5",
-    "zlib": "1.2.8",
-    "openssl": "1.0.2e",
-    "modules": "47",
-    "chrome": "47.0.2526.110",
-    "files": [
-      "darwin-x64",
-      "darwin-x64-symbols",
-      "linux-ia32",
-      "linux-ia32-symbols",
-      "linux-x64",
-      "linux-x64-symbols",
-      "win32-ia32",
-      "win32-ia32-symbols",
-      "win32-x64",
-      "win32-x64-symbols"
-    ]
-  },
-  {
     "version": "0.37.1",
     "date": "2016-03-14",
     "node": "5.1.1",
@@ -1320,6 +1320,29 @@
     "openssl": "1.0.2e",
     "modules": "47",
     "chrome": "49.0.2623.75",
+    "files": [
+      "darwin-x64",
+      "darwin-x64-symbols",
+      "linux-ia32",
+      "linux-ia32-symbols",
+      "linux-x64",
+      "linux-x64-symbols",
+      "win32-ia32",
+      "win32-ia32-symbols",
+      "win32-x64",
+      "win32-x64-symbols"
+    ]
+  },
+  {
+    "version": "0.36.12",
+    "date": "2016-03-27",
+    "node": "5.1.1",
+    "v8": "4.7.80.27",
+    "uv": "1.7.5",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2e",
+    "modules": "47",
+    "chrome": "47.0.2526.110",
     "files": [
       "darwin-x64",
       "darwin-x64-symbols",
@@ -1541,29 +1564,6 @@
     ]
   },
   {
-    "version": "0.35.5",
-    "date": "2015-12-31",
-    "node": "4.1.1",
-    "v8": "4.5.103.29",
-    "uv": "1.7.4",
-    "zlib": "1.2.8",
-    "openssl": "1.0.2d",
-    "modules": "46",
-    "chrome": "45.0.2454.85",
-    "files": [
-      "darwin-x64",
-      "darwin-x64-symbols",
-      "linux-ia32",
-      "linux-ia32-symbols",
-      "linux-x64",
-      "linux-x64-symbols",
-      "win32-ia32",
-      "win32-ia32-symbols",
-      "win32-x64",
-      "win32-x64-symbols"
-    ]
-  },
-  {
     "version": "0.36.2",
     "date": "2015-12-25",
     "node": "5.1.1",
@@ -1596,6 +1596,29 @@
     "openssl": "1.0.2e",
     "modules": "47",
     "chrome": "47.0.2526.73",
+    "files": [
+      "darwin-x64",
+      "darwin-x64-symbols",
+      "linux-ia32",
+      "linux-ia32-symbols",
+      "linux-x64",
+      "linux-x64-symbols",
+      "win32-ia32",
+      "win32-ia32-symbols",
+      "win32-x64",
+      "win32-x64-symbols"
+    ]
+  },
+  {
+    "version": "0.35.5",
+    "date": "2015-12-31",
+    "node": "4.1.1",
+    "v8": "4.5.103.29",
+    "uv": "1.7.4",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2d",
+    "modules": "46",
+    "chrome": "45.0.2454.85",
     "files": [
       "darwin-x64",
       "darwin-x64-symbols",
@@ -1679,8 +1702,8 @@
     ]
   },
   {
-    "version": "0.34.4",
-    "date": "2015-11-24",
+    "version": "0.35.1",
+    "date": "2015-11-26",
     "node": "4.1.1",
     "v8": "4.5.103.29",
     "uv": "1.7.4",
@@ -1702,8 +1725,8 @@
     ]
   },
   {
-    "version": "0.35.1",
-    "date": "2015-11-26",
+    "version": "0.34.4",
+    "date": "2015-11-24",
     "node": "4.1.1",
     "v8": "4.5.103.29",
     "uv": "1.7.4",

--- a/script/versions
+++ b/script/versions
@@ -8,6 +8,7 @@ const path = require('path')
 const fetchDocs = require('electron-docs')
 const Doc = require('../lib/doc')
 const got = require('got')
+const semver = require('semver')
 const versionsUrl = 'https://atom.io/download/electron/index.json'
 
 console.log(`Downloading version data from ${versionsUrl}`)
@@ -15,6 +16,7 @@ console.log(`Downloading version data from ${versionsUrl}`)
 got(versionsUrl, {json: true})
   .then(response => {
     const versions = response.body
+      .sort((a, b) => semver.compare(b.version, a.version))
     const filepath = path.join(__dirname, '../_data/versions.json')
     console.log(`Saving version data to ${filepath}`)
     fs.writeFileSync(filepath, JSON.stringify(versions, null, 2))


### PR DESCRIPTION
I set up the GitHub releases data to be sorted with highest version first, but forgot to do it for the supplementary v8/node/chromium version data that we collect from https://atom.io/download/electron/index.json

This PR fixes that.