### PR TITLE
Fix the links to old docs

### DIFF
--- a/_pages/docs-versions.md
+++ b/_pages/docs-versions.md
@@ -9,5 +9,5 @@ category: ignore
 ## Older Versions
 
 {% for version in site.data.versions %}
-- [{{ version.version }}](https://github.com/electron/electron/tree/{{ version.version }}/docs)
+- [{{ version.version }}](https://github.com/electron/electron/tree/v{{ version.version }}/docs)
 {% endfor %}


### PR DESCRIPTION
Fixes the issues raised in: https://twitter.com/amsoell/status/842674759053852676 that links to old documentation didn't work