### PR TITLE
Don't convert fragment links

### DIFF
--- a/_docs/api/browser-window.md
+++ b/_docs/api/browser-window.md
@@ -597,7 +597,7 @@ Force closing the window, the `unload` and `beforeunload` event won't be emitted
 
 #### `win.close()`
 
-Try to close the window. This has the same effect as a user manually clicking the close button of the window. The web page may cancel the close though. See the [close event]({{site.baseurl}}/docs/api/#event-close).
+Try to close the window. This has the same effect as a user manually clicking the close button of the window. The web page may cancel the close though. See the [close event](#event-close).
 
 #### `win.focus()`
 

--- a/_docs/api/client-request.md
+++ b/_docs/api/client-request.md
@@ -166,7 +166,7 @@ Process: [Main]({{site.baseurl}}/docs/glossary#main-process)
     *   `hostname` String (optional) - The server host name.
     *   `port` Integer (optional) - The server's listening port number.
     *   `path` String (optional) - The path part of the request URL.
-    *   `redirect` String (optional) - The redirect mode for this request. Should be one of `follow`, `error` or `manual`. Defaults to `follow`. When mode is `error`, any redirection will be aborted. When mode is `manual` the redirection will be deferred until [`request.followRedirect`]({{site.baseurl}}/docs/api/#requestfollowRedirect) is invoked. Listen for the [`redirect`]({{site.baseurl}}/docs/api/#event-redirect) event in this mode to get more details about the redirect request.
+    *   `redirect` String (optional) - The redirect mode for this request. Should be one of `follow`, `error` or `manual`. Defaults to `follow`. When mode is `error`, any redirection will be aborted. When mode is `manual` the redirection will be deferred until [`request.followRedirect`](#requestfollowRedirect) is invoked. Listen for the [`redirect`](#event-redirect) event in this mode to get more details about the redirect request.
 
 `options` properties such as `protocol`, `host`, `hostname`, `port` and `path` strictly follow the Node.js model as described in the [URL](https://nodejs.org/api/url.html) module.
 
@@ -260,7 +260,7 @@ Returns:
 *   `redirectUrl` String
 *   `responseHeaders` Object
 
-Emitted when there is redirection and the mode is `manual`. Calling [`request.followRedirect`]({{site.baseurl}}/docs/api/#requestfollowRedirect) will continue with the redirection.
+Emitted when there is redirection and the mode is `manual`. Calling [`request.followRedirect`](#requestfollowRedirect) will continue with the redirection.
 
 ### Instance Properties
 

--- a/_docs/api/menu-item.md
+++ b/_docs/api/menu-item.md
@@ -161,7 +161,7 @@ See [`Menu`]({{site.baseurl}}/docs/api/menu) for examples.
         *   `menuItem` MenuItem
         *   `browserWindow` BrowserWindow
         *   `event` Event
-    *   `role` String (optional) - Define the action of the menu item, when specified the `click` property will be ignored. See [roles]({{site.baseurl}}/docs/api/#roles).
+    *   `role` String (optional) - Define the action of the menu item, when specified the `click` property will be ignored. See [roles](#roles).
     *   `type` String (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or `radio`.
     *   `label` String - (optional)
     *   `sublabel` String - (optional)

--- a/_docs/api/session.md
+++ b/_docs/api/session.md
@@ -471,7 +471,7 @@ Returns `Blob` - The blob data associated with the `identifier`.
     *   `eTag` String - ETag header value.
     *   `startTime` Double (optional) - Time when download was started in number of seconds since UNIX epoch.
 
-Allows resuming `cancelled` or `interrupted` downloads from previous `Session`. The API will generate a [DownloadItem]({{site.baseurl}}/docs/api/download-item) that can be accessed with the [will-download]({{site.baseurl}}/docs/api/#event-will-download) event. The [DownloadItem]({{site.baseurl}}/docs/api/download-item) will not have any `WebContents` associated with it and the initial state will be `interrupted`. The download will start only when the `resume` API is called on the [DownloadItem]({{site.baseurl}}/docs/api/download-item).
+Allows resuming `cancelled` or `interrupted` downloads from previous `Session`. The API will generate a [DownloadItem]({{site.baseurl}}/docs/api/download-item) that can be accessed with the [will-download](#event-will-download) event. The [DownloadItem]({{site.baseurl}}/docs/api/download-item) will not have any `WebContents` associated with it and the initial state will be `interrupted`. The download will start only when the `resume` API is called on the [DownloadItem]({{site.baseurl}}/docs/api/download-item).
 
 #### `ses.clearAuthCache(options[, callback])`
 

--- a/_docs/glossary.md
+++ b/_docs/glossary.md
@@ -158,7 +158,7 @@ The ASAR format was created primarily to improve performance on Windows... TODO
 
 ### Brightray
 
-[Brightray](https://github.com/electron/brightray) is a static library that makes [libchromiumcontent]({{site.baseurl}}/docs/#libchromiumcontent) easier to use in applications. It was created specifically for Electron, but can be used to enable Chromium's renderer in native apps that are not based on Electron.
+[Brightray](https://github.com/electron/brightray) is a static library that makes [libchromiumcontent](#libchromiumcontent) easier to use in applications. It was created specifically for Electron, but can be used to enable Chromium's renderer in native apps that are not based on Electron.
 
 Brightray is a low-level dependency of Electron that does not concern the majority of Electron users.
 
@@ -168,11 +168,11 @@ An Apple Disk Image is a packaging format used by macOS. DMG files are commonly 
 
 ### IPC
 
-IPC stands for Inter-Process Communication. Electron uses IPC to send serialized JSON messages between the [main]({{site.baseurl}}/docs/#main-process) and [renderer]({{site.baseurl}}/docs/#renderer-process) processes.
+IPC stands for Inter-Process Communication. Electron uses IPC to send serialized JSON messages between the [main](#main-process) and [renderer](#renderer-process) processes.
 
 ### libchromiumcontent
 
-A single, shared library that includes the Chromium Content module and all its dependencies (e.g., Blink, [V8]({{site.baseurl}}/docs/#v8), etc.).
+A single, shared library that includes the Chromium Content module and all its dependencies (e.g., Blink, [V8](#v8), etc.).
 
 ### main process
 
@@ -180,7 +180,7 @@ The main process, commonly a file named `main.js`, is the entry point to every E
 
 Every app's main process file is specified in the `main` property in `package.json`. This is how `electron .` knows what file to execute at startup.
 
-See also: [process]({{site.baseurl}}/docs/#process), [renderer process]({{site.baseurl}}/docs/#renderer-process)
+See also: [process](#process), [renderer process](#renderer-process)
 
 ### MAS
 
@@ -200,11 +200,11 @@ Nullsoft Scriptable Install System is a script-driven Installer authoring tool f
 
 ### process
 
-A process is an instance of a computer program that is being executed. Electron apps that make use of the [main]({{site.baseurl}}/docs/#main-process) and one or many [renderer]({{site.baseurl}}/docs/#renderer-process) process are actually running several programs simultaneously.
+A process is an instance of a computer program that is being executed. Electron apps that make use of the [main](#main-process) and one or many [renderer](#renderer-process) process are actually running several programs simultaneously.
 
 In Node.js and Electron, each running process has a `process` object. This object is a global that provides information about, and control over, the current process. As a global, it is always available to applications without using require().
 
-See also: [main process]({{site.baseurl}}/docs/#main-process), [renderer process]({{site.baseurl}}/docs/#renderer-process)
+See also: [main process](#main-process), [renderer process](#renderer-process)
 
 ### renderer process
 
@@ -212,7 +212,7 @@ The renderer process is a browser window in your app. Unlike the main process, t
 
 In normal browsers, web pages usually run in a sandboxed environment and are not allowed access to native resources. Electron users, however, have the power to use Node.js APIs in web pages allowing lower level operating system interactions.
 
-See also: [process]({{site.baseurl}}/docs/#process), [main process]({{site.baseurl}}/docs/#main-process)
+See also: [process](#process), [main process](#main-process)
 
 ### Squirrel
 

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -22,7 +22,7 @@ module.exports = class Doc {
       const href = this.$(el).attr('href')
 
       // Ignore links to other sections of the page
-      if (href && href[0] === '#') return
+      if (href != null && href[0] === '#') return
 
       const type = hrefType(href)
       if (type !== 'relative' && type !== 'rooted') return

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -20,6 +20,10 @@ module.exports = class Doc {
     // Fix relative links
     this.$('a').each((i, el) => {
       const href = this.$(el).attr('href')
+
+      // Ignore links to other sections of the page
+      if (href && href[0] === '#') return
+
       const type = hrefType(href)
       if (type !== 'relative' && type !== 'rooted') return
       const dirname = path.dirname(`/docs/${this.filename}`)

--- a/test.js
+++ b/test.js
@@ -54,6 +54,11 @@ describe('electron.atom.io', () => {
       expect(httpLinks.length).to.be.above(3)
     })
 
+    it('leaves fragment links intact', () => {
+      const doc = loadDoc('api/menu-item.md')
+      expect(doc).to.include('[roles](#roles)')
+    })
+
     it('preserves fenced js code snippets', () => {
       const doc = loadDoc('api/clipboard.md')
       expect(doc).to.include('```javascript\n')


### PR DESCRIPTION
Fragments links are currently being converted to be rooted at the wrong page, this pull request changes the link converter to ignore them.

Refs https://github.com/electron/electron/pull/9065#issuecomment-296514242