### PR TITLE
update href-types package for fragment link detection

### DIFF
--- a/lib/doc.js
+++ b/lib/doc.js
@@ -20,10 +20,6 @@ module.exports = class Doc {
     // Fix relative links
     this.$('a').each((i, el) => {
       const href = this.$(el).attr('href')
-
-      // Ignore links to other sections of the page
-      if (href != null && href[0] === '#') return
-
       const type = hrefType(href)
       if (type !== 'relative' && type !== 'rooted') return
       const dirname = path.dirname(`/docs/${this.filename}`)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-link-checker": "^0.1.0",
-    "href-type": "^1.0.0",
+    "href-type": "^1.0.1",
     "marky-markdown-lite": "^1.2.0",
     "mocha": "^3.2.0",
     "npm-run-all": "^3.1.2",


### PR DESCRIPTION
A followup to https://github.com/electron/electron.atom.io/pull/725 that updates the `href-type` package with support for detecting fragment URLs like `#about-us`