### PR TITLE
post deployment errors to a gist

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "electron-apps": "^1.3.0",
     "electron-docs": "^3.0.0",
     "electron-userland-reports": "1.6.0",
+    "github": "^9.2.0",
     "got": "^6.6.3",
     "gray-matter": "^2.1.0",
     "grunt": "^0.4.5",

--- a/script/notify
+++ b/script/notify
@@ -1,26 +1,45 @@
 #!/usr/bin/env node
 
-// Load SLACK_WEBHOOK from .env (for local testing)
 require('dotenv').load()
 
+const GitHub = require('github')
+const github = new GitHub({
+  debug: true,
+  headers: {'User-Agent': 'electron.atom.io'}
+})
+github.authenticate({
+  type: 'oauth',
+  token: process.env.GITHUB_AUTH_TOKEN
+})
 const slack = require('slack-notify')(process.env.SLACK_WEBHOOK)
-var input = ''
+var stackTrace = ''
 
 // Collect STDOUT and STDERR from release script
 process.stdin
   .setEncoding('utf8')
-  .on('readable', () => { input += String(process.stdin.read() || '') })
-  .on('end', send)
+  .on('readable', () => { stackTrace += String(process.stdin.read() || '') })
+  .on('end', createGist)
 
-function send () {
-  if (!input.match('npm ERR') && !input.match('Test failed')) {
+function createGist () {
+  if (!stackTrace.match('npm ERR') && !stackTrace.match('Test failed')) {
     return process.exit()
   }
 
+  github.gists.create({
+    files: {'error': {content: stackTrace}},
+    public: false,
+    description: 'An error message from the electron.atom.io deployment process'
+  }, function (err, gist) {
+    if (err) throw err
+    postToSlack(gist.data.html_url)
+  })
+}
+
+function postToSlack (gistUrl) {
   const opts = {
     icon_url: 'https://avatars0.githubusercontent.com/u/18403005?v=3',
     username: 'electron.atom.io',
-    text: ['```', input, '```'].join('\n')
+    text: `There was an error deploying the website: ${gistUrl}`
   }
 
   slack.send(opts, (err) => {


### PR DESCRIPTION
Problem: Slack is getting spammed with stack traces that most people don't want to see.

Solution: Update the deployment process to post failures to a gist, then notify in slack with the gist URL.