### PR TITLE
Fix missing open bracket in quick start title

### DIFF
--- a/_data/locale.yml
+++ b/_data/locale.yml
@@ -71,11 +71,11 @@ quick_start:
   clone: Clone the Quick Start repository
   go_into_repo: Go into the repository
   install_deps: Install the dependencies and run
-  dive_deeper: Or dive deeper and read the <a href='{{ site.baseurl }}/docs/'>documentation</a>.
+  dive_deeper: Or dive deeper and read the <a href='https://electron.atom.io/docs/'>documentation</a>.
 
 need_help:
   title: Need Help?
-  description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum or our <a href='http://atom-slack.herokuapp.com/'>Slack</a> channel. Follow <a href="https://twitter.com/{{ site.twitter_username }}">@{{ site.twitter_username }}</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:electron@github.com">electron@github.com</a>.
+  description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum or our <a href='http://atom-slack.herokuapp.com/'>Slack</a> channel. Follow <a href="https://twitter.com/ElectronJS">@ElectronJS</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:electron@github.com">electron@github.com</a>.
 
 apps:
   title: Apps built on Electron

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -141,7 +141,7 @@ lang: en
       <hr>
 
     <h3 class="mb-3">
-      { site.data.locale.quick_start.title }}
+      {{ site.data.locale.quick_start.title }}
     </h3>
     <p>{{ site.data.locale.quick_start.description }}</p>
     


### PR DESCRIPTION
Was browsing the site when I noticed the Quick Start title wasn't loading properly. Noticed it was missing the opening brace so I fixed it!