### PR TITLE
[Update] The logic of a sentence

### DIFF
--- a/_docs/api/crash-reporter.md
+++ b/_docs/api/crash-reporter.md
@@ -242,7 +242,7 @@ This would normally be controlled by user preferences. This has no effect if cal
 *   `key` String - Parameter key.
 *   `value` String - Parameter value. Specifying `null` or `undefined` will remove the key from the extra parameters.
 
-Set an extra parameter to set be sent with the crash report. The values specified here will be sent in addition to any values set via the `extra` option when `start` was called. This API is only available on macOS, if you need to add/update extra parameters on Linux and Windows after your first call to `start` you can call `start` again with the updated `extra` options.
+Set an extra parameter to be sent with the crash report. The values specified here will be sent in addition to any values set via the `extra` option when `start` was called. This API is only available on macOS, if you need to add/update extra parameters on Linux and Windows after your first call to `start` you can call `start` again with the updated `extra` options.
 
 ## Crash Report Payload
 


### PR DESCRIPTION
**Set an extra parameter to set be sent with the crash report** was corrected to

**Set an extra parameter to be sent with the crash report**