### PR TITLE
Add DockStation app into featured

### DIFF
--- a/_data/featured_apps.json
+++ b/_data/featured_apps.json
@@ -21,4 +21,6 @@
   "svgsus",
   "visual-studio-code",
   "webtorrent",
-  "wordpress-com" ]
+  "wordpress-com",
+  "dockstation"
+ ]


### PR DESCRIPTION
Hi guys. We made a great free tool for developers who's make and manage projects based on Docker. I think that the DockStation app could be worthy of being on the main page.
You can get more information about app here: https://dockstation.io/