### PR TITLE
tweak browserync watched files

### DIFF
--- a/lib/browsersync.js
+++ b/lib/browsersync.js
@@ -6,7 +6,14 @@ module.exports = function browsersync () {
 
   const bs = require('browser-sync')({
     port: 3030,
-    files: path.join(__dirname, '../**/*'),
+    files: [
+      path.join(__dirname, '../**/*.md'),
+      path.join(__dirname, '../**/*.html'),
+      path.join(__dirname, '../**/*.css'),
+      path.join(__dirname, '../**/*.scss'),
+      path.join(__dirname, '../data/**/*'),
+      path.join(__dirname, '../js/**/*')
+    ],
     logSnippet: false
   })
   return require('connect-browser-sync')(bs)


### PR DESCRIPTION
Editing files like `server.js` was causing browsersync to refresh, and because I am a convulsive file-saver, the browser refresh would sometimes occur when `server.js` contained malformed code. As such, browsersync would sometimes refresh at a time when the server would crash, occasionally  requiring a manual browser refresh.

This change is an attempt to solve that issue by preventing browsersync from refreshing when server-side JS files are being edited.