### PR TITLE
migrate contact page

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -89,3 +89,10 @@ apps:
   submit_your_own: submit your own
 
 or: or
+
+pages:
+  '/contact':
+    title: Contact
+    permalink: /contact/
+    layout: default
+    description: Get in touch with the Electron team on Twitter, Slack, GitHub, or via email.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,10 @@ const path = require('path')
 const express = require('express')
 const hbs = require('express-hbs')
 const i18n = require('electron-i18n')
+
+// TODO(zeke): Get locale from `i18n` instead
+const localized = require('require-yml')('./data/locale.yml')
+
 const slashes = require('connect-slashes')
 const browsersync = require('./lib/browsersync')()
 const electronApps = require('./data/apps.json')
@@ -92,6 +96,13 @@ app.get('/apps/:slug', (req, res) => {
     context.pageDetails.image = `${host}/images/apps/${app.icon64}`
   }
   res.render('app', context)
+})
+
+app.get('/contact', (req, res) => {
+  const context = {
+    pageDetails: Object.assign({}, localized.pages[req.path])
+  }
+  res.render('contact', context)
 })
 
 function startServer () {

--- a/views/contact.html
+++ b/views/contact.html
@@ -1,10 +1,3 @@
----
-title: Contact
-permalink: /contact/
-layout: default
-excerpt: Get in touch with the Electron team on Twitter, Slack, GitHub, or via email.
----
-
 <div class='subtron'>
   <div class='container-narrow'>
     <h1>Get in touch</h1>
@@ -16,12 +9,12 @@ excerpt: Get in touch with the Electron team on Twitter, Slack, GitHub, or via e
 
     <div class='row my-4'>
       <h2 class="col-xs-12 col-md-3"><span class="octicon mega-octicon octicon-mark-github pr-3"></span>GitHub</h2>
-      <h2 class="col-xs-12 col-md-9"><a href="https://github.com/{{ site.github_username }}">@{{ site.github_username }}</a></h2>
+      <h2 class="col-xs-12 col-md-9"><a href="https://github.com/electron">@electron</a></h2>
     </div>
 
     <div class='row my-4'>
       <h2 class="col-xs-12 col-md-3"><span class="octicon mega-octicon octicon-mention pr-3"></span>Twitter</h2>
-      <h2 class="col-xs-12 col-md-9"><a href="https://twitter.com/{{ site.twitter_username }}">@{{ site.twitter_username }}</a></h2>
+      <h2 class="col-xs-12 col-md-9"><a href="https://twitter.com/electronjs">@electronjs</a></h2>
     </div>
 
     <div class='row my-4'>
@@ -36,7 +29,7 @@ excerpt: Get in touch with the Electron team on Twitter, Slack, GitHub, or via e
 
     <div class='row my-4'>
       <h2 class="col-xs-12 col-md-3"><span class="octicon mega-octicon octicon-mail pr-3"></span>Email</h2>
-      <h2 class="col-xs-12 col-md-9"><a href="mailto:{{ site.email }}">{{ site.email }}</a></h2>
+      <h2 class="col-xs-12 col-md-9"><a href="mailto:electron@github.com">electron@github.com</a></h2>
     </div>
 
   </div>


### PR DESCRIPTION
One of my goals this week is to chip away at the jekyll-to-node migration: #758

This little PR ports the `/contact` page from Jekyll style to Express style, and paves the way for injecting pages with localized `<meta>` data like  `title` and `description`