### PR TITLE
add app.json for heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,19 @@
+{
+  "name": "electron.atom.io",
+  "description": "",
+  "scripts": {},
+  "env": {
+    "PAPERTRAIL_API_TOKEN": {
+      "required": true
+    }
+  },
+  "formation": {},
+  "addons": [
+    "papertrail"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}


### PR DESCRIPTION
Not actually needed for this branch, but Heroku requires it for Review Apps to work.