### PR TITLE
use derived colors on app pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,6 @@
         "stable": "0.1.6"
       }
     },
-    "accept-language-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.4.1.tgz",
-      "integrity": "sha1-OHdPqbgtHzj3MVr0QxZaIZDMgnY="
-    },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
@@ -1302,18 +1297,14 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-apps": {
-      "version": "1.1682.0",
-      "resolved": "https://registry.npmjs.org/electron-apps/-/electron-apps-1.1682.0.tgz",
-      "integrity": "sha512-6xQVq8gO6OqBEhEtO/B0+vq366XuEL8EHNC8fgSmBqN6xDwFrubzJPbX39U8vkUm1X3BQva90skAW5Z7G6XJdA=="
+      "version": "1.1693.0",
+      "resolved": "https://registry.npmjs.org/electron-apps/-/electron-apps-1.1693.0.tgz",
+      "integrity": "sha512-V9ubsaBZDRwlweMQqEtHFDUSwUJ+cFEZH6RXDDPPXnpuysmy7GEtjQV7cD3xP3vZK9lkOia9Fakr3MduLgpvPQ=="
     },
     "electron-i18n": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-0.5.0.tgz",
-      "integrity": "sha512-djnTcjjjwva3I08/qrEc90q6w+AlsS1LmDWRVDlNnGi3Y8k1BNa4PvtfbziOKc8c8WSxYDETtK6tCwDdN1wEAA==",
-      "requires": {
-        "accept-language-parser": "1.4.1",
-        "express-request-language": "1.1.12"
-      }
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-0.7.2.tgz",
+      "integrity": "sha512-HSZ8DxCb+SghzrnkscTJbKmw0sODG+1KC7xJHhOP5Uu9v3u92zo6kak+9ZWHi9dUMhnlYmHRxqRVl4jvnNuWTw=="
     },
     "electron-userland-reports": {
       "version": "1.6.0",
@@ -4124,6 +4115,14 @@
         "strip-bom": "2.0.0"
       }
     },
+    "lobars": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lobars/-/lobars-1.2.0.tgz",
+      "integrity": "sha1-QRJBhFT5rgVk1Dttq8hRUp2oFX8=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "localtunnel": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
@@ -5724,6 +5723,11 @@
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
         }
       }
+    },
+    "require-dir": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
+      "integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "connect-slashes": "^1.3.1",
     "cookie-parser": "^1.4.3",
     "dotenv": "^4.0.0",
-    "electron-apps": "^1.1682.0",
+    "electron-apps": "^1.1693.0",
     "electron-i18n": "^0.7.2",
     "electron-userland-reports": "1.6.0",
     "express": "^4.15.3",

--- a/views/apps/show.html
+++ b/views/apps/show.html
@@ -1,3 +1,14 @@
+<style>
+  .app-download {
+    background: {{app.goodColorOnWhite}}; 
+    color: white !important;
+  }
+
+  .page-section a {
+    color: {{app.goodColorOnWhite}}; 
+  }
+</style>
+
 <section class="page-section">
 
   <nav aria-label="Breadcrumb">


### PR DESCRIPTION
Update app pages to use accessible colors for links and buttons. Colors are derived from the app icon and are guaranteed to be [accessible](https://github.com/zeke/make-color-accessible).