### PR TITLE
Sort apps by date

### DIFF
--- a/lib/apps.js
+++ b/lib/apps.js
@@ -25,9 +25,11 @@ const featured = [
   'wordpress-com'
 ]
 
-const apps = require('electron-apps').map(app => {
-  app.featured = featured.includes(app.slug)
-  return app
-})
+const apps = require('electron-apps')
+  .map(app => {
+    app.featured = featured.includes(app.slug)
+    return app
+  })
+  .sort((a, b) => new Date(b.date) - new Date(a.date))
 
 module.exports = apps

--- a/package-lock.json
+++ b/package-lock.json
@@ -2352,9 +2352,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-apps": {
-      "version": "1.1727.0",
-      "resolved": "https://registry.npmjs.org/electron-apps/-/electron-apps-1.1727.0.tgz",
-      "integrity": "sha512-wDEBxuyVKKkgRucIMpvkPa06lrEyurNS6xrt9m5GuKiCxouzHIZONDqgV4eXlWAJbAymg2SZgats1D3HfOOcDQ=="
+      "version": "1.1729.0",
+      "resolved": "https://registry.npmjs.org/electron-apps/-/electron-apps-1.1729.0.tgz",
+      "integrity": "sha512-rwwW8TbtfDAVzN8CZWe+A02Yfy3OobjkMKrchQdnQsgiMMLrkCM4xwsLv3oqgWPtdcfR3AW9zTCS557zVuIZkQ=="
     },
     "electron-i18n": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "connect-slashes": "^1.3.1",
     "cookie-parser": "^1.4.3",
     "dotenv": "^4.0.0",
-    "electron-apps": "^1.1727.0",
+    "electron-apps": "^1.1729.0",
     "electron-i18n": "^0.7.2",
     "electron-userland-reports": "1.6.0",
     "express": "^4.15.3",

--- a/routes/apps/index.js
+++ b/routes/apps/index.js
@@ -1,4 +1,4 @@
-const apps = require('electron-apps')
+const apps = require('../../lib/apps')
 const categories = require('electron-apps/categories')
 
 module.exports = (req, res) => {

--- a/scripts/update-app-download-links.js
+++ b/scripts/update-app-download-links.js
@@ -28,5 +28,4 @@ module.exports = function updateAppDownloadLinks () {
   if (links.length > 1) {
     document.querySelector('#view-all-downloads').style.display = 'inline-block'
   }
-  
 }

--- a/server.js
+++ b/server.js
@@ -70,7 +70,7 @@ app.get('/docs/:category/*', routes.docs.show)
 app.get('/userland', routes.userland.index)
 app.get('/userland/*', routes.userland.show)
 
-app.get('/maintainers/join', (req, res) => res.redirect("https://goo.gl/FJmZZm"))
+app.get('/maintainers/join', (req, res) => res.redirect('https://goo.gl/FJmZZm'))
 app.get('/community', routes.community)
 app.get('/languages', routes.languages.index)
 app.get('/contact', routes.contact)

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,17 @@ describe('electron.atom.io', () => {
       $('.category-list li').length.should.be.above(15)
     })
 
+    test('apps are sorted by date, descending', async () => {
+      const $ = await get('/apps')
+      const dates = $('.listed-app [data-date]')
+        .map((i, el) => new Date($(el).text()))
+        .get()
+
+      const clone = dates.slice(0)
+      dates.length.should.be.above(10)
+      clone.sort((a, b) => new Date(b) - new Date(a)).should.deep.equal(dates)
+    })
+
     test('index filtered by category', async () => {
       const $ = await get('/apps?category=games')
       $('.listed-app').length.should.be.above(15)

--- a/views/apps/index.html
+++ b/views/apps/index.html
@@ -2,9 +2,7 @@
 
   <div class="col-xs-3 px-4">    
 
-    <h3>Search</h3>
-
-    <input class="filterable-list-input" placeholder="Filter by name, description, etc..." type="search" autofocus="on" tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">    
+    <input class="filterable-list-input" placeholder="Filter apps by name, description, etc..." type="search" autofocus="on" tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">    
 
     <h3>Categories</h3>
 

--- a/views/community.html
+++ b/views/community.html
@@ -96,7 +96,7 @@
     </table>
 
     <p class="mt-3 mt-md-6">
-      To add a meetup, edit <code>data/meetups.json</code> and <a href="https://github.com/electron/electron.atom.io/edit/gh-pages/_data/meetups.yml">make a pull request</a>.
+      To add a meetup, edit <code>data/meetups.json</code> and <a href="https://github.com/electron/electron.atom.io/edit/master/data/meetups.yml">make a pull request</a>.
     </p>
   </div>
 </section>


### PR DESCRIPTION
Some people visit the site periodically looking for the latest app additions. This way the newest stuff is always on top. Eventually we should enable sorting by other things: name, popularity, etc. But in the mean time this PR makes the behavior consistent with the existing site.