### PR TITLE
Syntax highlighting

### DIFF
--- a/middleware/browsersync.js
+++ b/middleware/browsersync.js
@@ -9,7 +9,6 @@ module.exports = function browsersync () {
     files: [
       path.join(__dirname, '../**/*.md'),
       path.join(__dirname, '../**/*.html'),
-      // path.join(__dirname, '../**/*.css'),
       // path.join(__dirname, '../**/*.scss'),
       path.join(__dirname, '../data/**/*'),
       path.join(__dirname, '../js/**/*')

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -13,6 +13,12 @@ a {
   color: $main-link-color;  // override Primer
 }
 
+h1,h2,h3,h4,h5,h6 {
+  a {
+    color: $main-color;  // override Primer
+  }
+}
+
 hr {
   border-color: $border-color; // override Primer
   margin-left: $spacer6 !important;

--- a/styles/_basecoat-code.scss
+++ b/styles/_basecoat-code.scss
@@ -40,6 +40,6 @@ h2,
 h3,
 h4 {
   code {
-    background-color: darken($main-bg-color, 10%);
+    background-color: darken($main-bg-color, 5%);
   }
 }

--- a/styles/hljs/github.css
+++ b/styles/hljs/github.css
@@ -1,0 +1,99 @@
+/*
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #009926;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #0086b3;
+}
+
+.hljs-meta {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/styles/hljs/overrides.scss
+++ b/styles/hljs/overrides.scss
@@ -1,0 +1,10 @@
+.hljs {
+  line-height: 1.6;
+  font-size: 1.2em; 
+  padding: 10px;
+}
+
+code:before {
+  letter-spacing: inherit;
+  content: '';
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -63,7 +63,8 @@ $octicons-font-path: "../bower_components/octicons/octicons/";
 // Electron -----------------------------------
 
 @import "base";
-@import "highlight"; // Syntax highlighting
+@import "hljs/github"; // Syntax highlighting
+@import "hljs/overrides"; // customization
 
 // Basecoat overrides
 @import "basecoat-buttons";

--- a/views/layouts/docs.html
+++ b/views/layouts/docs.html
@@ -1,11 +1,12 @@
 {{!< main}}
 
 <div class='subtron text-left'>
-  <h1><span class="mr-3 mr-lg-4">Electron Documentation</span><span class="docs-version">{{electronLatestStableVersion}}</span></h1>
+  <!-- <h1><span class="mr-3 mr-lg-4">Electron Documentation</span><span class="docs-version">{{electronLatestStableVersion}}</span></h1> -->
 
   <div class='container-narrow'>
 
     <h4 class="docs-breadcrumbs">
+      <a href='/'>Electron {{electronLatestStableVersion}}</a> /
       <a href='/docs/'>Docs</a> /
       {{#if category}}
         {{category}}


### PR DESCRIPTION
Jekyll has its own [set of tools](https://jekyllrb.com/docs/templates/#code-snippet-highlighting) that do syntax highlighting for code snippets. We're now using [remark](http://ghub.io/remark) to parse markdown and the [remark-highlight.js](http://ghub.io/remark-highlight.js) plugin for code snippets. They use different approaches to structuring the code, and different CSS classes for the various code components like comments, keywords, builtins, etc.

I pulled in the GitHub Highlight.js theme from here: https://github.com/isagalaev/highlight.js/blob/master/src/styles/github.css, then added a little bit of styling to get it mostly consistent with what we had before.

Before:

![screen shot 2017-10-23 at 2 05 06 pm](https://user-images.githubusercontent.com/2289/31913154-3548e7f8-b7fb-11e7-8a5e-d7b9424038e5.png)

After:

![screen shot 2017-10-23 at 2 05 11 pm](https://user-images.githubusercontent.com/2289/31913163-3c967110-b7fb-11e7-8c86-54d336f3b5ac.png)


cc @simurai @donokuda