### PR TITLE
localize docs footer

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -77,6 +77,15 @@ need_help:
   title: Need Help?
   description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum or our <a href='http://atom-slack.herokuapp.com/'>Slack</a> channel. Follow <a href="https://twitter.com/{{ site.twitter_username }}">@{{ site.twitter_username }}</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:electron@github.com">electron@github.com</a>.
 
+footer:
+  see_something: See something that needs fixing?
+  propose_change: Propose a change to the source file.
+  need_different_version: Need a different version of the docs?
+  see_available_versions: See available versions.
+  want_something_searchable: Want something searchable?
+  view_all_docs: View all docs on one page
+  see_the_faq: See the frequently asked questions
+
 apps:
   title: Apps built on Electron
   description:
@@ -89,9 +98,6 @@ apps:
   submit_your_own: submit your own
 
 or: or
-
-view_all_docs: View all the docs on one page
-see_the_faq: See the frequently asked questions
 
 pages:
   '/apps':

--- a/views/docs/index.html
+++ b/views/docs/index.html
@@ -49,8 +49,8 @@
 
 <section class="page-section page-section-spacious">
   <p class="text-center">
-      <a href="/docs/all/">{{localized.view_all_docs}}</a> 
+      <a href="/docs/all/">{{localized.footer.view_all_docs}}</a> 
       {{localized.or}}
-    <a href="/docs/faq/">{{localized.see_the_faq}}</a>.
+    <a href="/docs/faq/">{{localized.footer.see_the_faq}}</a>.
   </p>
 </section>

--- a/views/partials/docs_footer.html
+++ b/views/partials/docs_footer.html
@@ -1,12 +1,19 @@
 <div class='text-center'>
   <span class="d-inline-block text-left">
+    
     <span class="octicon octicon-pencil mr-2"></span>
-    See something that needs fixing? Propose a change on the <a href='{{ page.source_url }}'>source</a>.
+    {{localized.footer.see_something}}
+    <a href='{{page.source_url}}'>{{localized.footer.propose_change}}</a>
     <br>
+
     <span class="octicon octicon-zap mr-2"></span>
-    Need a different version of the docs? See the <a href='/docs/versions/'>available versions</a> or <a href="https://github.com/electron/electron/tree/master/docs-translations">community translations</a>.
+    {{localized.footer.need_different_version}}
+    <a href='/docs/versions/'>{{localized.footer.see_available_versions}}</a>
     <br>
+
     <span class="octicon octicon-book mr-2"></span>
-    Want to search all the documentation at once? See all of the <a href='/docs/all'>docs on one page</a>.
+    {{localized.footer.want_something_searchable}}
+    <a href='/docs/all'>{{localized.footer.view_all_docs}}</a>  
+
   </span>
 </div>


### PR DESCRIPTION
This PR moves more strings into `locale.yml` so they can be translated.