### PR TITLE
Locale Nav

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,3 @@
 language: node_js
-
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-
 node_js:
   - "8"
-
-env:
-  global:
-    - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
-
-branches:
-  only:
-    - gh-pages
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-
-env:
-  CXX=g++-4.8

--- a/data/locale.yml
+++ b/data/locale.yml
@@ -8,6 +8,7 @@ nav:
   userland: Userland
   releases: Releases
   contact: Contact
+  languages: Languages
 
 electron_is_easy:
   title: It's easier than you think

--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -1,6 +1,7 @@
 const i18n = require('../lib/i18n')
 const vendoredVersions = require('../data/versions.json')
   .find(version => version.version === i18n.electronLatestStableVersion)
+const {getLanguageNativeName} = require('locale-code')
 
 // Supply all route handlers with a baseline `req.context` object
 module.exports = function contextBuilder (req, res, next) {
@@ -10,6 +11,7 @@ module.exports = function contextBuilder (req, res, next) {
     electronLatestStableTag: i18n.electronLatestStableTag,
     vendoredVersions: vendoredVersions,
     currentLocale: req.language,
+    currentLocaleNativeName: getLanguageNativeName(req.language),
     locales: i18n.locales,
     page: i18n.website[req.language].pages[req.path],
     localized: i18n.website[req.language],

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lil-env-thing": "^1.0.0",
     "list.js": "^1.5.0",
     "lobars": "^1.2.0",
+    "locale-code": "^1.1.1",
     "lodash": "^4.17.4",
     "make-promises-safe": "^1.1.0",
     "minimist": "^1.2.0",

--- a/server.js
+++ b/server.js
@@ -45,7 +45,6 @@ app.use(requestLanguage({
   languages: Object.keys(i18n.locales),
   cookie: {
     name: 'language',
-    options: {maxAge: 24 * 60 * 60 * 1000},
     url: '/languages/{language}'
   }
 }))

--- a/styles/_basecoat-tables.scss
+++ b/styles/_basecoat-tables.scss
@@ -9,9 +9,9 @@
   width: 100%;
 }
 
-.table-ruled td {
+.table-ruled td, .table-ruled th {
   padding: $spacer2;
-  line-height: 1.4;
+  line-height: 2;
   text-align: left;
   font-size: 14px;
 }

--- a/styles/_nav.scss
+++ b/styles/_nav.scss
@@ -1,6 +1,20 @@
 .site-header a {
+  transition: all 0.3s;
+}
+
+.site-header nav a {
   line-height: 2.3;
+  border-bottom: 2px solid transparent;
   &.active, &:active, &:hover {
-    border-bottom: 2px solid $jumbo-color-strong;
+    border-bottom-color: $jumbo-color-strong;
+  }
+
+  &.bordered {
+    border: 1px solid $jumbo-color-strong;
+    border-radius: 3px;
+    padding: 0 7px;
+    opacity: 0.7;
+    font-size: 12px;
+    line-height: 2;
   }
 }

--- a/views/partials/footer.html
+++ b/views/partials/footer.html
@@ -2,12 +2,13 @@
   <div class="container">
     <nav class="footer-nav">
       <a class="footer-nav-item" href="/">Electron</a>
-      <a class="footer-nav-item" href="/docs">{{ localized.nav.docs }}</a>
-      <a class="footer-nav-item" href="/blog">{{ localized.nav.blog }}</a>
-      <a class="footer-nav-item" href="/community">{{ localized.nav.community }}</a>
-      <a class="footer-nav-item" href="/apps">{{ localized.nav.apps }}</a>
-      <a class="footer-nav-item" href="/releases">{{ localized.nav.releases }}</a>
-      <a class="footer-nav-item" href="/contact">{{ localized.nav.contact }}</a>
+      <a class="footer-nav-item" href="/docs">{{localized.nav.docs}}</a>
+      <a class="footer-nav-item" href="/blog">{{localized.nav.blog}}</a>
+      <a class="footer-nav-item" href="/community">{{localized.nav.community}}</a>
+      <a class="footer-nav-item" href="/apps">{{localized.nav.apps}}</a>
+      <a class="footer-nav-item" href="/releases">{{localized.nav.releases}}</a>
+      <a class="footer-nav-item" href="/contact">{{localized.nav.contact}}</a>
+      <a class="footer-nav-item" href="/languages">{{localized.nav.languages}}</a>
     </nav>
     <span class="footer-love">
       <a href='https://github.com' class="no-underline"><span class='octicon octicon-code'></span> with <span class='octicon octicon-heart'></span> by <span class='octicon octicon-logo-github'></span></a>

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -17,14 +17,15 @@
     </a>
 
     <nav class="site-header-nav">
-      <a class="site-header-nav-item" href="/docs/">{{ localized.nav.docs }}</a>
-      <a class="site-header-nav-item" href="/blog/">{{ localized.nav.blog }}</a>
-      <a class="site-header-nav-item" href="/community/">{{ localized.nav.community }}</a>
-      <a class="site-header-nav-item" href="/apps/">{{ localized.nav.apps }}</a>
-      <a class="site-header-nav-item" href="/userland/">{{ localized.nav.userland }}</a>
-      <a class="site-header-nav-item" href="/releases/">{{ localized.nav.releases }}</a>
-      <a class="site-header-nav-item" href="/contact/">{{ localized.nav.contact }}</a>
-      <a class="site-header-nav-item" href="https://github.com/electron/electron" title="Github Repository"><span class="mega-octicon octicon-mark-github vertical-middle"></span></a>
+      <a class="site-header-nav-item" href="/apps">{{localized.nav.apps}}</a>
+      <a class="site-header-nav-item" href="/docs">{{localized.nav.docs}}</a>
+      <a class="site-header-nav-item" href="/blog">{{localized.nav.blog}}</a>
+      <a class="site-header-nav-item" href="/community">{{localized.nav.community}}</a>
+      <!-- <a class="site-header-nav-item" href="/userland">{{localized.nav.userland}}</a> -->
+      <a class="site-header-nav-item" href="/releases">{{localized.nav.releases}}</a>
+      <a class="site-header-nav-item" href="/contact">{{localized.nav.contact}}</a>
+      <a class="site-header-nav-item" href="https://github.com/electron" title="Github Organization"><span class="mega-octicon octicon-mark-github vertical-middle"></a>
+      <a class="site-header-nav-item bordered" href="/languages">{{currentLocaleNativeName}}</a>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
This PR adds the user's currently selected language to the right edge of the header nav.

Here it is in English, which everyone defaults to, regardless of their browser's `accept-language` header:

![screen shot 2017-11-08 at 6 37 36 pm](https://user-images.githubusercontent.com/2289/32585792-02d1a95c-c4b4-11e7-8558-842e54a93e31.png)

And in Japanese:

<img width="794" alt="screen shot 2017-11-08 at 12 47 19 pm" src="https://user-images.githubusercontent.com/2289/32585757-d7079048-c4b3-11e7-939d-083562d266fb.png">

And in Chinese on mobile:

![screen shot 2017-11-08 at 6 43 08 pm](https://user-images.githubusercontent.com/2289/32585932-b97900ce-c4b4-11e7-8437-b511f33c99f9.png)

Clicking on the language leads to `/languages` where another language can be chosen. The choice persists in an everlasting cookie. 🍪 

cc @donokuda @groundwater @vanessayuenn 