### PR TITLE
lock primer-breadcrumb at 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -317,6 +317,79 @@
         "js-tokens": "3.0.2"
       }
     },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
@@ -431,6 +504,15 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -765,6 +847,20 @@
         "browserslist": "2.5.1",
         "invariant": "2.2.2",
         "semver": "5.4.1"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1820,6 +1916,11 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
     },
+    "convert-source-map": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+    },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -2145,6 +2246,14 @@
         "repeat-string": "1.6.1"
       }
     },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
     "detective": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
@@ -2318,9 +2427,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-apps": {
-      "version": "1.1729.0",
-      "resolved": "https://registry.npmjs.org/electron-apps/-/electron-apps-1.1729.0.tgz",
-      "integrity": "sha512-rwwW8TbtfDAVzN8CZWe+A02Yfy3OobjkMKrchQdnQsgiMMLrkCM4xwsLv3oqgWPtdcfR3AW9zTCS557zVuIZkQ=="
+      "version": "1.1837.0",
+      "resolved": "https://registry.npmjs.org/electron-apps/-/electron-apps-1.1837.0.tgz",
+      "integrity": "sha512-WtSsQHE2AmpsN5xS2Ojn1zK/570HNwHXd2gXL/DRqJg3GD+tMGGCseUyjLR7IKdr0oyGHZsKH9kllyaVPTYKfA=="
     },
     "electron-i18n": {
       "version": "0.9.1",
@@ -4556,6 +4665,15 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -5290,6 +5408,11 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "3.0.1",
@@ -7045,25 +7168,23 @@
       "integrity": "sha1-y+NiRxPP9IAfSqBTGsP58iTTOqU="
     },
     "primer-breadcrumb": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/primer-breadcrumb/-/primer-breadcrumb-1.4.1.tgz",
-      "integrity": "sha512-cmDjIXSXClLQcrWDeJkZJWXkacfCluZU23mfsVM8K0oZyhiHZjbleOdsbwGXMKpFSEJ61wi4zvF9ZMkx1s8EdA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/primer-breadcrumb/-/primer-breadcrumb-1.0.2.tgz",
+      "integrity": "sha1-WVi8DbEJV/ZBQXAHyrfJybSkk/8=",
       "requires": {
         "primer-marketing-support": "1.3.1",
         "primer-support": "4.4.1"
-      },
-      "dependencies": {
-        "primer-marketing-support": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/primer-marketing-support/-/primer-marketing-support-1.3.1.tgz",
-          "integrity": "sha512-GDwQ4TdZNS4p6UbSMxv7j7DlgegEDU43k2QKFJZ9EAtBN/rOKkf9gBa31yEiJQvgG7wZ84CvioObYtw885TL7g=="
-        },
-        "primer-support": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.4.1.tgz",
-          "integrity": "sha512-stQEoF4NfWy8JOVASUHxGY+Ot1eBguPH8rWoeLQy16zKzcS16kRccfvGbBXyv0G/aA+DdL8ZmjlXB2ubJ+wBJg=="
-        }
       }
+    },
+    "primer-marketing-support": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/primer-marketing-support/-/primer-marketing-support-1.3.1.tgz",
+      "integrity": "sha512-GDwQ4TdZNS4p6UbSMxv7j7DlgegEDU43k2QKFJZ9EAtBN/rOKkf9gBa31yEiJQvgG7wZ84CvioObYtw885TL7g=="
+    },
+    "primer-support": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.4.1.tgz",
+      "integrity": "sha512-stQEoF4NfWy8JOVASUHxGY+Ot1eBguPH8rWoeLQy16zKzcS16kRccfvGbBXyv0G/aA+DdL8ZmjlXB2ubJ+wBJg=="
     },
     "private": {
       "version": "0.1.8",
@@ -8050,6 +8171,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
@@ -8183,6 +8309,21 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
         "amdefine": "1.0.1"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
       }
     },
     "space-separated-tokens": {
@@ -8929,6 +9070,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "trim-trailing-lines": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "^0.5.1",
     "node-sass-middleware": "^0.11.0",
     "platform-utils": "^1.0.0",
-    "primer-breadcrumb": "1.4.1",
+    "primer-breadcrumb": "1.0.2",
     "query-string": "^5.0.0",
     "require-dir": "^0.3.2",
     "require-directory": "^2.1.1",


### PR DESCRIPTION
This problem popped up again after Greenkeeper updated primer-breadcrumb in #805.

https://github.com/electron/electron.atom.io/pull/806

https://github.com/primer/primer-css/issues/317