### PR TITLE
Fix Address of Korea Community

### DIFF
--- a/data/meetups.json
+++ b/data/meetups.json
@@ -14,7 +14,7 @@
     "name": "Electron Korea",
     "location": "Seoul",
     "country": "South Korea",
-    "href": "http://www.meetup.com/electron-kr"
+    "href": "https://electron-kr.github.io/electron-kr"
   },
   {
     "name": "Austin ElectronJS Meetup",


### PR DESCRIPTION
fix address to "https://electron-kr.github.io/electron-kr"
I changed it to '@ragingwind' request.
You can refer to #11078 in electron/electron