### PR TITLE
Better 404

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -166,3 +166,8 @@ pages:
     description: Get in touch with the Electron team on Twitter, Slack, GitHub, or via email.
   '/languages':
     title: Languages
+
+_404:
+  page_not_found: Page not found.
+  if_this_is_an_error: If this is an error
+  please_file_an_issue: please file an issue.

--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -5,7 +5,6 @@ const {getLanguageNativeName} = require('locale-code')
 
 // Supply all route handlers with a baseline `req.context` object
 module.exports = function contextBuilder (req, res, next) {
-  
   // Attach i18n object to request so any route handler can use it if needed
   req.i18n = i18n
 
@@ -26,10 +25,10 @@ module.exports = function contextBuilder (req, res, next) {
   }
 
   if (req.path !== '/' && req.context.page && !req.context.page.titled) {
-    req.context.page.titled = true;
+    req.context.page.titled = true
     req.context.page.title = `${req.context.page.title} | Electron`
   }
-  
+
   if (req.path.startsWith('/docs')) {
     req.context.docs = i18n.docs[req.language]
   }

--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -5,7 +5,14 @@ const {getLanguageNativeName} = require('locale-code')
 
 // Supply all route handlers with a baseline `req.context` object
 module.exports = function contextBuilder (req, res, next) {
+  
+  // Attach i18n object to request so any route handler can use it if needed
   req.i18n = i18n
+
+  // Page titles, descriptions, etc
+  const page = i18n.website[req.language].pages[req.path] || {}
+  page.path = req.path
+
   req.context = {
     electronLatestStableVersion: i18n.electronLatestStableVersion,
     electronLatestStableTag: i18n.electronLatestStableTag,
@@ -13,7 +20,7 @@ module.exports = function contextBuilder (req, res, next) {
     currentLocale: req.language,
     currentLocaleNativeName: getLanguageNativeName(req.language),
     locales: i18n.locales,
-    page: i18n.website[req.language].pages[req.path],
+    page: page,
     localized: i18n.website[req.language],
     cookies: req.cookies
   }

--- a/routes/_404.js
+++ b/routes/_404.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.render('404', req.context)
+}

--- a/routes/_404.js
+++ b/routes/_404.js
@@ -1,3 +1,9 @@
 module.exports = (req, res) => {
-  res.render('404', req.context)
+  const context = Object.assign(req.context, {
+    page: {
+      title: '404 Not Found | Electron'
+    }
+  })
+
+  res.render('404', context)
 }

--- a/routes/apps/index.js
+++ b/routes/apps/index.js
@@ -1,7 +1,7 @@
 const apps = require('../../lib/apps')
 const categories = require('electron-apps/categories')
 
-module.exports = (req, res) => {
+module.exports = (req, res, next) => {
   const context = Object.assign(req.context, {
     apps: apps,
     categories: categories
@@ -10,10 +10,8 @@ module.exports = (req, res) => {
   if (req.query.category) {
     const category = categories.find(category => category.slug === req.query.category)
 
-    if (!category) {
-      return res.status(404).render('404', {message: 'Category not found'})
-    }
-
+    if (!category) return next()
+    
     context.apps = apps.filter((app) => app.category === category.name)
     context.categories = categories.map(category => {
       category.className = (category.slug === req.query.category) ? 'selected' : ''

--- a/routes/apps/index.js
+++ b/routes/apps/index.js
@@ -11,7 +11,7 @@ module.exports = (req, res, next) => {
     const category = categories.find(category => category.slug === req.query.category)
 
     if (!category) return next()
-    
+
     context.apps = apps.filter((app) => app.category === category.name)
     context.categories = categories.map(category => {
       category.className = (category.slug === req.query.category) ? 'selected' : ''

--- a/server.js
+++ b/server.js
@@ -77,17 +77,7 @@ app.get('/contact', routes.contact)
 app.get('/releases', routes.releases)
 
 // Generic 404 handler
-<<<<<<< HEAD
-app.use((req, res, next) => {
-  res.status(404).render('404', {
-    page: {
-      title: '404 Not Found | Electron'
-    }
-  })
-})
-=======
 app.use(routes._404)
->>>>>>> localize 404 page
 
 if (!module.parent) {
   app.listen(port, () => {

--- a/server.js
+++ b/server.js
@@ -77,6 +77,7 @@ app.get('/contact', routes.contact)
 app.get('/releases', routes.releases)
 
 // Generic 404 handler
+<<<<<<< HEAD
 app.use((req, res, next) => {
   res.status(404).render('404', {
     page: {
@@ -84,6 +85,9 @@ app.use((req, res, next) => {
     }
   })
 })
+=======
+app.use(routes._404)
+>>>>>>> localize 404 page
 
 if (!module.parent) {
   app.listen(port, () => {

--- a/test/index.js
+++ b/test/index.js
@@ -150,9 +150,9 @@ describe('electron.atom.io', () => {
     const $ = await get('/community')
     $('.subtron .container-narrow h1').text().should.eq(i18n.website['vi-VN'].community.title)
   })
-  
+
   describe('userland', () => {
-     test('userland/404', async () => {
+    test('userland/404', async () => {
       const $ = await get('/userland/404')
       $('.page-section.error-page').length.should.eq(1)
     })

--- a/views/404.html
+++ b/views/404.html
@@ -5,8 +5,11 @@
       {{#if message}}
         {{message}}
       {{else}}
-        This page could not be found.
+        {{localized._404.page_not_found}}
       {{/if}}
+
+      {{localized._404.if_this_is_an_error}}
+      <a href="https://github.com/electron/electron.atom.io/issues/new?title=404%20for%20{{page.path}}&body=The%20following%20route%20is%20returning%20a%20404%20HTTP%20status%20code%3A%20{{page.path}}">{{localized._404.please_file_an_issue}}</a>.
     </p>
   </div>
 </section>


### PR DESCRIPTION
Created a 404 handler instead of just rendering the 404 page, so that all `req.context` is available to render the nav etc. Localized the 404 page and made sure that all missing routes are reaching the new default handler. Added a link to open an issue on GitHub that includes the 404-ing path.