### PR TITLE
Help section now links to correct twitter account

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -109,7 +109,7 @@ quick_start:
 
 need_help:
   title: Need Help?
-  description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum or our <a href='http://atom-slack.herokuapp.com/'>Slack</a> channel. Follow <a href="https://twitter.com/{{ site.twitter_username }}">@{{ site.twitter_username }}</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:electron@github.com">electron@github.com</a>.
+  description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum or our <a href='http://atom-slack.herokuapp.com/'>Slack</a> channel. Follow <a href="https://twitter.com/electronjs">@electronjs</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:electron@github.com">electron@github.com</a>.
 
 headings:
   languages: Languages


### PR DESCRIPTION
I looked elsewhere and could not find a mention of twitter_username, but there are a couple of direct links to twitter.com/electronjs (just search this repo for "twitter"), so I opted to fix it that way (as the other links in this section are direct links too)