### PR TITLE
Hide app categories on mobile

### DIFF
--- a/styles/_app.scss
+++ b/styles/_app.scss
@@ -124,3 +124,22 @@
 .linux-only {
   display: none;
 }
+
+// hide filter categories on
+@media only screen and (max-width: 750px) {
+  .categories-filter {
+    display: none;
+  }
+  .inline-filter {
+    display: block;
+  }
+  .container-narrow {
+    width: 100%;
+  }
+}
+
+@media only screen and (min-width: 750px) {
+  .inline-filter {
+    display: none;
+  }
+}

--- a/styles/_app.scss
+++ b/styles/_app.scss
@@ -125,7 +125,7 @@
   display: none;
 }
 
-// hide filter categories on
+// hide filter categories on mobile
 @media only screen and (max-width: 750px) {
   .categories-filter {
     display: none;
@@ -138,6 +138,7 @@
   }
 }
 
+// only show inline filter on mobile
 @media only screen and (min-width: 750px) {
   .inline-filter {
     display: none;

--- a/views/apps/index.html
+++ b/views/apps/index.html
@@ -1,8 +1,8 @@
 <section class='page-section'>
 
-  <div class="col-xs-3 px-4">    
+  <div class="col-xs-3 px-4 categories-filter">
 
-    <input class="filterable-list-input" placeholder="Filter apps by name, description, etc..." type="search" autofocus="on" tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">    
+    <input class="filterable-list-input" placeholder="Filter apps by name, description, etc..." type="search" autofocus="on" tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
 
     <h3>Categories</h3>
 
@@ -27,6 +27,7 @@
   </div>
 
   <div class='col-xs-9 container-narrow text-center' id="apps">
+    <input class="inline-filter filterable-list-input" placeholder="Filter apps by name, description, etc..." type="search" autofocus="on" tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
 
     <ul class="mb-4 filterable-list app-list">
       {{#each apps}}
@@ -41,7 +42,7 @@
               <span class='listed-app-date text-gray-light'>Added&nbsp;<span data-date='{{this.date}}'>{{this.date}}</span></span>
               <span class='listed-app-keywords' style='display:none;'>
                 {{this.keywords}}
-                
+
                 {{#if this.homebrewCaskName}}
                   homebrew cask
                 {{/if}}


### PR DESCRIPTION
This PR hides app categories on mobile, but leaves filter and moves it above the app list. 

<img width="1178" alt="screen shot 2017-11-15 at 3 43 39 pm" src="https://user-images.githubusercontent.com/2036040/32859206-cc88f086-ca1b-11e7-8f9d-7e41338d5c76.png">

<img width="687" alt="screen shot 2017-11-15 at 3 43 48 pm" src="https://user-images.githubusercontent.com/2036040/32859212-cf9e839e-ca1b-11e7-819c-27701fce6c9a.png">


/cc @zeke 