### PR TITLE
redirect issues urls to github

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,6 +66,9 @@ app.get('/docs', routes.docs.index)
 app.get('/docs/:category', routes.docs.category)
 app.get('/docs/:category/*', routes.docs.show)
 
+app.get('/issues', (req, res) => res.redirect(301, 'https://github.com/electron/electron.atom.io/issues'))
+app.get('/issues/new', (req, res) => res.redirect(301, 'https://github.com/electron/electron.atom.io/issues/new'))
+
 app.get('/userland', routes.userland.index)
 app.get('/userland/*', routes.userland.show)
 

--- a/test/index.js
+++ b/test/index.js
@@ -203,4 +203,18 @@ describe('electron.atom.io', () => {
     res.statusCode.should.equal(301)
     res.headers.location.should.equal('/apps')
   })
+
+  describe('issues', () => {
+    test('redirects /issues to the website repo, for convenience', async () => {
+      const res = await supertest(app).get('/issues')
+      res.statusCode.should.equal(301)
+      res.headers.location.should.equal('https://github.com/electron/electron.atom.io/issues')
+    })
+
+    test('redirects /issues/new to the website repo, for convenience', async () => {
+      const res = await supertest(app).get('/issues')
+      res.statusCode.should.equal(301)
+      res.headers.location.should.equal('https://github.com/electron/electron.atom.io/issues')
+    })
+  })
 })


### PR DESCRIPTION
I keep typing electron.atom.io/issues into my browser address bar and ending up at a 404 page. This change will solve that for me by redirecting to the GitHub repo's issue pages.